### PR TITLE
Fix vulnerable dependency versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
 assertj-ver = "3.24.2"
-avro-ver = "1.11.3"
+avro-ver = "1.11.4"
 awaitility-ver = "4.2.0"
 bson-ver = "4.11.0"
-hadoop-ver = "3.3.6"
+hadoop-ver = "3.4.1"
 hive-ver = "2.3.9"
 http-client-ver = "5.2.1"
 iceberg-ver = "1.5.2"

--- a/kafka-connect-runtime/build.gradle
+++ b/kafka-connect-runtime/build.gradle
@@ -11,9 +11,10 @@ configurations {
     resolutionStrategy.force "org.xerial.snappy:snappy-java:1.1.10.5"
     resolutionStrategy.force "org.apache.commons:commons-compress:1.26.0"
     resolutionStrategy.force "org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1-tabular"
+    resolutionStrategy.force "io.airlift:aircompressor:0.27"
     resolutionStrategy.eachDependency { details ->
       if (details.requested.group == "io.netty") {
-        details.useVersion "4.1.100.Final"
+        details.useVersion "4.1.115.Final"
       }
     }
   }


### PR DESCRIPTION
### Purpose of the change
Some of the currently used dependencies are vulnerable. To fix this, its required to bump it's versions.

List of vulnerable dependencies and their CVEs:
- io.airlift:aircompressor (Bumping from `0.26` to `0.27` - `CVE-2024-36114`)
- hadoop-common (Bumping from `3.36` to `3.4.1` due to vulnerability in dnsjava:dnsjava (version `2.1.7` to `3.6.1`) `CVE-2024-25638`)
- org.apache.avro:avro (Bumping from `1.11.3` to `1.11.4` - `CVE-2024-47561`)
- io.netty:netty-common (Bumping from `4.1.100.Final` to `4.1.115.Final` - `CVE-2024-47535`)

### Testing
It was not tested out yet, but distribution build passess.