### PR TITLE
Usd 2624/Fix way iceberg jars are packaged to kafka connect

### DIFF
--- a/kafka-connect-runtime/build.gradle
+++ b/kafka-connect-runtime/build.gradle
@@ -32,6 +32,7 @@ task downloadIcebergJars {
 }
 
 configurations {
+  customJars
   hive {
     extendsFrom runtimeClasspath
   }
@@ -69,7 +70,6 @@ dependencies {
     exclude group: "org.eclipse.jetty"
   }
   runtimeOnly libs.bundles.iceberg.ext
-  runtimeOnly files("$buildDir/libs/iceberg-aws-bundle-1.7.0-SNAPSHOT.jar", "$buildDir/libs/iceberg-azure-bundle-1.7.0-SNAPSHOT.jar")
 
   hive libs.iceberg.hive.metastore
   hive(libs.hive.metastore) {
@@ -99,6 +99,7 @@ dependencies {
   }
 
   testImplementation libs.bundles.iceberg
+
   testImplementation files("$buildDir/libs/iceberg-aws-bundle-1.7.0-SNAPSHOT.jar")
   testImplementation files("$buildDir/libs/iceberg-azure-bundle-1.7.0-SNAPSHOT.jar")
 
@@ -123,6 +124,30 @@ processResources {
   }
 }
 
+// Add a task to verify the custom JARs exist
+task verifyCustomJars {
+  dependsOn downloadIcebergJars
+  doLast {
+    def awsBundle = file("$buildDir/libs/iceberg-aws-bundle-1.7.0-SNAPSHOT.jar")
+    def azureBundle = file("$buildDir/libs/iceberg-azure-bundle-1.7.0-SNAPSHOT.jar")
+
+    if (!awsBundle.exists()) {
+      throw new GradleException("Missing iceberg-aws-bundle-1.7.0-SNAPSHOT.jar in ${awsBundle.absolutePath}")
+    }
+
+    if (!azureBundle.exists()) {
+      throw new GradleException("Missing iceberg-azure-bundle-1.7.0-SNAPSHOT.jar in ${azureBundle.absolutePath}")
+    }
+
+    println "Custom JARs exist:"
+    println "- ${awsBundle.absolutePath}"
+    println "- ${azureBundle.absolutePath}"
+  }
+}
+
+// Make sure downloadIcebergJars runs after clean and before other tasks
+downloadIcebergJars.mustRunAfter clean
+
 distributions {
   main {
     contents {
@@ -131,6 +156,11 @@ distributions {
       }
       into("lib/") {
         from configurations.runtimeClasspath
+        // Add custom JARs explicitly to the distribution
+        from fileTree(dir: "$buildDir/libs", include: [
+                "iceberg-aws-bundle-1.7.0-SNAPSHOT.jar",
+                "iceberg-azure-bundle-1.7.0-SNAPSHOT.jar"
+        ])
       }
       into("doc/") {
         from "$rootDir/LICENSE"
@@ -174,16 +204,20 @@ publishing {
 tasks.jar.enabled = false
 
 tasks.distTar.enabled = false
-distZip.dependsOn processResources
-installDist.dependsOn processResources
-
 tasks.hiveDistTar.enabled = false
-hiveDistZip.dependsOn processResources
-installHiveDist.dependsOn processResources
+
+tasks.distZip.dependsOn processResources, verifyCustomJars
+tasks.hiveDistZip.dependsOn processResources, verifyCustomJars
+tasks.installDist.dependsOn processResources, verifyCustomJars
+tasks.installHiveDist.dependsOn processResources, verifyCustomJars
+
+// Ensure the verifyCustomJars task depends on downloadIcebergJars
+verifyCustomJars.dependsOn downloadIcebergJars
+
+// make sure compileJava also depends on downloadIcebergJars
+compileJava.dependsOn downloadIcebergJars
 
 // build the install before test so it can be installed into kafka connect
 test.dependsOn installDist
-
-tasks.compileJava.dependsOn downloadIcebergJars
 
 assemble.dependsOn distZip, hiveDistZip


### PR DESCRIPTION
https://rapid7.atlassian.net/browse/USD-2624

Add custom JARs explicitly to the distribution

Have tested and we do not see errors
Caused by: java.lang.NoSuchMethodException: Cannot find constructor for interface org.apache.iceberg.catalog.Catalog
Caused by: java.lang.ClassNotFoundException: software.amazon.awssdk.services.glue.model.EntityNotFoundException