### PR TITLE
Bump the version of libraries used

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+ant-ver = "1.10.11"
 assertj-ver = "3.24.2"
 avro-ver = "1.11.4"
 aircompressor = "0.27"
@@ -22,10 +23,12 @@ parquet-avro-ver = "1.15.2"
 protobuf-java-ver = "3.25.5"
 slf4j-ver = "1.7.36"
 testcontainers-ver = "1.17.6"
-
+libthrift-ver = "0.15.0"
+zookeeper-ver = "3.8.3"
 
 
 [libraries]
+ant = { module = "org.apache.ant:ant", version.ref = "ant-ver" }
 avro = { module = "org.apache.avro:avro", version.ref = "avro-ver" }
 aircompressor = { module = "io.airlift:aircompressor", version.ref = "aircompressor" }
 commonsBeanutils = { module = "commons-beanutils:commons-beanutils", version.ref = "commonsBeanutils-ver" }
@@ -58,6 +61,7 @@ kafka-clients = { module = "org.apache.kafka:kafka-clients", version.ref = "kafk
 kafka-connect-api = { module = "org.apache.kafka:connect-api", version.ref = "kafka-ver" }
 kafka-connect-json = { module = "org.apache.kafka:connect-json", version.ref = "kafka-ver" }
 kafka-connect-transforms = { module = "org.apache.kafka:connect-transforms", version.ref = "kafka-ver" }
+libthrift = { module = "org.apache.thrift:libthrift", version.ref = "libthrift-ver" }
 netty-codec-http = { module = "io.netty:netty-codec-http", version.ref = "netty-ver" }
 netty-common = { module = "io.netty:netty-common", version.ref = "netty-ver" }
 netty-handler = { module = "io.netty:netty-handler", version.ref = "netty-ver" }
@@ -66,6 +70,7 @@ protobuf-java = { module = "com.google.protobuf:protobuf-java", version.ref = "p
 slf4j = { module = "org.slf4j:slf4j-api", version.ref = "slf4j-ver" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback-ver" }
 logback-core = { module = "ch.qos.logback:logback-core", version.ref = "logback-ver" }
+zookeeper = { module = "org.apache.zookeeper:zookeeper", version.ref = "zookeeper-ver" }
 
 # test dependencies
 assertj = { module = "org.assertj:assertj-core", version.ref = "assertj-ver" }

--- a/kafka-connect-runtime/build.gradle
+++ b/kafka-connect-runtime/build.gradle
@@ -78,6 +78,12 @@ dependencies {
   implementation libs.logback.core
   implementation libs.jackson.core
   implementation libs.guava
+  implementation libs.zookeeper
+  implementation libs.netty.common
+  implementation libs.netty.handler
+  implementation libs.netty.codec.http
+  implementation libs.libthrift
+  implementation libs.ant
   implementation libs.parquet.avro
   implementation (group: 'org.apache.iceberg', name: 'iceberg-data', version: '1.6.1') {
     exclude group: 'org.apache.avro', module: 'avro'
@@ -147,6 +153,12 @@ dependencies {
   testImplementation libs.logback.core
   testImplementation libs.jackson.core
   testImplementation libs.guava
+  testImplementation libs.zookeeper
+  testImplementation libs.netty.common
+  testImplementation libs.netty.handler
+  testImplementation libs.netty.codec.http
+  testImplementation libs.libthrift
+  testImplementation libs.ant
   testImplementation libs.parquet.avro
   testImplementation (group: 'org.apache.iceberg', name: 'iceberg-data', version: '1.6.1') {
     exclude group: 'org.apache.avro', module: 'avro'

--- a/kafka-connect/build.gradle
+++ b/kafka-connect/build.gradle
@@ -12,6 +12,16 @@ dependencies {
   implementation libs.netty.handler
   implementation libs.netty.codec.http
   implementation libs.jetty.server
+  implementation libs.parquet.avro
+  implementation (group: 'org.apache.iceberg', name: 'iceberg-data', version: '1.6.1') {
+    exclude group: 'org.apache.avro', module: 'avro'
+    exclude group: 'org.apache.parquet', module: 'avro'
+  }
+
+  implementation (group: 'org.apache.iceberg', name: 'iceberg-parquet', version: '1.6.1') {
+    exclude group: 'org.apache.avro', module: 'avro'
+    exclude group: 'org.apache.parquet', module: 'avro'
+  }
 
   compileOnly libs.bundles.kafka.connect
 
@@ -35,6 +45,16 @@ dependencies {
   testImplementation libs.netty.handler
   testImplementation libs.netty.codec.http
   testImplementation libs.jetty.server
+  testImplementation libs.parquet.avro
+  testImplementation (group: 'org.apache.iceberg', name: 'iceberg-data', version: '1.6.1') {
+    exclude group: 'org.apache.avro', module: 'avro'
+    exclude group: 'org.apache.parquet', module: 'avro'
+  }
+
+  testImplementation (group: 'org.apache.iceberg', name: 'iceberg-parquet', version: '1.6.1') {
+    exclude group: 'org.apache.avro', module: 'avro'
+    exclude group: 'org.apache.parquet', module: 'avro'
+  }
 }
 
 configurations {


### PR DESCRIPTION
Upgrade various libraries to their latest versions to address security vulnerabilities and improve functionality.

This includes updates to

zookeeper
ant
libthrift