### PR TITLE
Refactor: Decouple txid capture in TransactionDataComplete

### DIFF
--- a/kafka-connect-events/src/main/java/io/tabular/iceberg/connect/events/TableTopicPartitionTransaction.java
+++ b/kafka-connect-events/src/main/java/io/tabular/iceberg/connect/events/TableTopicPartitionTransaction.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.tabular.iceberg.connect.events;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.avro.Schema;
+import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
+
+public class TableTopicPartitionTransaction implements org.apache.avro.generic.IndexedRecord {
+
+    private String topic;
+    private Integer partition;
+    private String catalogName;
+    private List<String> namespace;
+    private String tableName;
+    private Long txId;
+
+    private final Schema avroSchema;
+
+    static final int TOPIC = 10_800;
+    static final int PARTITION = 10_801;
+    static final int TX_ID = 10_802;
+    static final int CATALOG_NAME = 10_803;
+    static final int NAMESPACE = 10_804;
+    static final int TABLE_NAME = 10_805;
+    static final int NAMESPACE_ELEMENT = 10_806;
+
+    public static final Types.StructType ICEBERG_SCHEMA =
+            Types.StructType.of(
+                    Types.NestedField.required(TOPIC, "topic", Types.StringType.get()),
+                    Types.NestedField.required(PARTITION, "partition", Types.IntegerType.get()),
+                    Types.NestedField.optional(TX_ID, "txId", Types.LongType.get()),
+                    Types.NestedField.required(CATALOG_NAME, "catalog_name", Types.StringType.get()),
+                    Types.NestedField.required(NAMESPACE, "namespace", Types.ListType.ofRequired(NAMESPACE_ELEMENT, Types.StringType.get())),
+                    Types.NestedField.required(TABLE_NAME, "table_name", Types.StringType.get())
+            );
+
+    private static final Schema AVRO_SCHEMA = AvroSchemaUtil.convert(ICEBERG_SCHEMA, TableTopicPartitionTransaction.class.getName());
+
+    public TableTopicPartitionTransaction(Schema avroSchema) {
+        this.avroSchema = avroSchema;
+    }
+
+    public TableTopicPartitionTransaction(String topic, int partition, String catalogName, TableIdentifier tableIdentifier, Long txId) {
+        this.topic = topic;
+        this.partition = partition;
+        this.catalogName = catalogName;
+        this.namespace = Lists.newArrayList(tableIdentifier.namespace().levels());
+        this.tableName = tableIdentifier.name();
+        this.txId = txId;
+        this.avroSchema = AVRO_SCHEMA;
+    }
+
+    public String topic() { return topic; }
+    public Integer partition() { return partition; }
+    public String catalogName() { return catalogName; }
+    public Long txId() { return txId; }
+
+    public TableIdentifier tableIdentifier() {
+        List<String> parts = Lists.newArrayList(namespace);
+        parts.add(tableName);
+        return TableIdentifier.of(parts.toArray(new String[0]));
+    }
+
+    @Override
+    public Schema getSchema() {
+        return avroSchema;
+    }
+
+    @Override
+    public void put(int i, Object v) {
+        switch (positionToId(i, avroSchema)) {
+            case TOPIC:
+                this.topic = v == null ? null : v.toString();
+                return;
+            case PARTITION:
+                this.partition = (Integer) v;
+                return;
+            case TX_ID:
+                this.txId = (Long) v;
+                return;
+            case CATALOG_NAME:
+                this.catalogName = v == null ? null : v.toString();
+                return;
+            case NAMESPACE:
+                if (v instanceof List) {
+                    this.namespace = ((List<?>) v).stream()
+                            .map(Object::toString)
+                            .collect(Collectors.toList());
+                }
+                return;
+            case TABLE_NAME:
+                this.tableName = v == null ? null : v.toString();
+                return;
+            default:
+                throw new IllegalArgumentException("Unknown field index: " + i);
+        }
+    }
+
+    @Override
+    public Object get(int i) {
+        switch (positionToId(i, avroSchema)) {
+            case TOPIC: return topic;
+            case PARTITION: return partition;
+            case TX_ID: return txId;
+            case CATALOG_NAME: return catalogName;
+            case NAMESPACE: return namespace;
+            case TABLE_NAME: return tableName;
+            default:
+                throw new IllegalArgumentException("Unknown field index: " + i);
+        }
+    }
+
+    static int positionToId(int position, Schema avroSchema) {
+        List<Schema.Field> fields = avroSchema.getFields();
+        Preconditions.checkArgument(
+                position >= 0 && position < fields.size(), "Invalid field position: " + position);
+        Object val = fields.get(position).getObjectProp(AvroSchemaUtil.FIELD_ID_PROP);
+        return val == null ? -1 : (int) val;
+    }
+}

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Channel.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Channel.java
@@ -56,7 +56,6 @@ public abstract class Channel {
   private final Admin admin;
   private final Map<Integer, Long> controlTopicOffsets = Maps.newHashMap();
   private final String producerId;
-  private final Map<Integer, Long> highestTxIdPerPartition = Maps.newHashMap();
 
   private final EventDecoder eventDecoder;
 
@@ -146,10 +145,6 @@ public abstract class Channel {
   protected Map<Integer, Long> controlTopicOffsets() {
     return controlTopicOffsets;
   }
-
-  protected Map<Integer, Long> highestTxIdPerPartition() {
-        return highestTxIdPerPartition;
-    }
 
   protected void commitConsumerOffsets() {
     Map<TopicPartition, OffsetAndMetadata> offsetsToCommit = Maps.newHashMap();

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Committable.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Committable.java
@@ -20,27 +20,27 @@ package io.tabular.iceberg.connect.channel;
 
 import io.tabular.iceberg.connect.data.Offset;
 import io.tabular.iceberg.connect.data.WriterResult;
+import io.tabular.iceberg.connect.events.TableTopicPartitionTransaction;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.kafka.common.TopicPartition;
-import java.util.stream.Collectors;
 
 class Committable {
 
   private final ImmutableMap<TopicPartition, Offset> offsetsByTopicPartition;
-  private final ImmutableMap<TopicPartition, Long> txIdsByTopicPartition;
+
+  private final ImmutableList<TableTopicPartitionTransaction> tableTxIds;
+
   private final ImmutableList<WriterResult> writerResults;
 
   Committable(
-          Map<TopicPartition, Offset> offsetsByTopicPartition, Map<TopicPartition, Long> txIdsByTopicPartition, List<WriterResult> writerResults) {
+          Map<TopicPartition, Offset> offsetsByTopicPartition,
+          List<TableTopicPartitionTransaction> tableTxIds,
+          List<WriterResult> writerResults) {
     this.offsetsByTopicPartition = ImmutableMap.copyOf(offsetsByTopicPartition);
-    this.txIdsByTopicPartition = ImmutableMap.copyOf(
-            txIdsByTopicPartition.entrySet().stream()
-                    .filter(entry -> entry.getValue() != null)
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
-    );
+    this.tableTxIds = ImmutableList.copyOf(tableTxIds);
     this.writerResults = ImmutableList.copyOf(writerResults);
   }
 
@@ -48,9 +48,9 @@ class Committable {
     return offsetsByTopicPartition;
   }
 
-    public Map<TopicPartition, Long> txIdsByTopicPartition() {
-        return txIdsByTopicPartition;
-    }
+  public List<TableTopicPartitionTransaction> getTableTxIds() {
+    return tableTxIds;
+  }
 
   public List<WriterResult> writerResults() {
     return writerResults;

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/CommitterImpl.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/CommitterImpl.java
@@ -23,6 +23,8 @@ import static java.util.stream.Collectors.toMap;
 
 import io.tabular.iceberg.connect.IcebergSinkConfig;
 import io.tabular.iceberg.connect.data.Offset;
+import io.tabular.iceberg.connect.events.TableTopicPartitionTransaction;
+import io.tabular.iceberg.connect.events.TransactionDataComplete;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
@@ -30,9 +32,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
-
-import io.tabular.iceberg.connect.events.TopicPartitionTransaction;
-import io.tabular.iceberg.connect.events.TransactionDataComplete;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.connect.events.DataWritten;
 import org.apache.iceberg.connect.events.Event;
@@ -178,14 +177,13 @@ public class CommitterImpl extends Channel implements Committer, AutoCloseable {
                 })
             .collect(toList());
 
-    List<TopicPartitionTransaction> txIds = committable.txIdsByTopicPartition().entrySet().stream()
-            .map(entry -> new TopicPartitionTransaction(entry.getKey().topic(), entry.getKey().partition(), entry.getValue()))
-            .collect(toList());
+    //  TableTopicPartitionTransactions now
+    List<TableTopicPartitionTransaction> tableTxIds = committable.getTableTxIds();
 
     Event commitReady =
-        new Event(
-            config.controlGroupId(),
-            new TransactionDataComplete(commitId, assignments, txIds));
+            new Event(
+                    config.controlGroupId(),
+                    new TransactionDataComplete(commitId, assignments, tableTxIds));
     events.add(commitReady);
 
     Map<TopicPartition, Offset> offsets = committable.offsetsByTopicPartition();

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/TaskImpl.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/TaskImpl.java
@@ -40,7 +40,11 @@ public class TaskImpl implements Task, AutoCloseable {
   @Override
   public void put(Collection<SinkRecord> sinkRecords) {
     writer.write(sinkRecords);
-    committer.commit(writer);
+    committer.commit(() -> {
+      Worker worker = (Worker) writer;
+      worker.beginCommit();
+      return worker.committable();
+    });
   }
 
   @Override

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CommitStateTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CommitStateTest.java
@@ -28,7 +28,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.UUID;
 
-import io.tabular.iceberg.connect.events.TopicPartitionTransaction;
+import io.tabular.iceberg.connect.events.TableTopicPartitionTransaction;
 import io.tabular.iceberg.connect.events.TransactionDataComplete;
 import org.apache.iceberg.connect.events.Event;
 import org.apache.iceberg.connect.events.Payload;
@@ -45,7 +45,7 @@ public class CommitStateTest {
   @Test
   public void testIsCommitReady() {
     TopicPartitionOffset tp = mock(TopicPartitionOffset.class);
-    TopicPartitionTransaction tpt = mock(TopicPartitionTransaction.class);
+    TableTopicPartitionTransaction tpt = mock(TableTopicPartitionTransaction.class);
 
     CommitState commitState = new CommitState(mock(IcebergSinkConfig.class));
     commitState.startNewCommit();
@@ -53,17 +53,17 @@ public class CommitStateTest {
     TransactionDataComplete payload1 = mock(TransactionDataComplete.class);
     when(payload1.commitId()).thenReturn(commitState.currentCommitId());
     when(payload1.assignments()).thenReturn(ImmutableList.of(tp, tp));
-    when(payload1.txIds()).thenReturn(ImmutableList.of(tpt, tpt));
+    when(payload1.tableTxIds()).thenReturn(ImmutableList.of(tpt, tpt));
 
     TransactionDataComplete payload2 = mock(TransactionDataComplete.class);
     when(payload2.commitId()).thenReturn(commitState.currentCommitId());
     when(payload2.assignments()).thenReturn(ImmutableList.of(tp));
-    when(payload2.txIds()).thenReturn(ImmutableList.of(tpt));
+    when(payload2.tableTxIds()).thenReturn(ImmutableList.of(tpt));
 
     TransactionDataComplete payload3 = mock(TransactionDataComplete.class);
     when(payload3.commitId()).thenReturn(UUID.randomUUID());
     when(payload3.assignments()).thenReturn(ImmutableList.of(tp));
-    when(payload3.txIds()).thenReturn(ImmutableList.of(tpt));
+    when(payload3.tableTxIds()).thenReturn(ImmutableList.of(tpt));
 
     commitState.addReady(wrapInEnvelope(payload1));
     commitState.addReady(wrapInEnvelope(payload2));

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CommitterImplTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CommitterImplTest.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -18,7 +18,6 @@
  */
 package io.tabular.iceberg.connect.channel;
 
-import static io.tabular.iceberg.connect.fixtures.EventTestUtil.createDataFile;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -31,6 +30,8 @@ import static org.mockito.Mockito.when;
 import io.tabular.iceberg.connect.IcebergSinkConfig;
 import io.tabular.iceberg.connect.data.Offset;
 import io.tabular.iceberg.connect.data.WriterResult;
+import io.tabular.iceberg.connect.events.TableTopicPartitionTransaction;
+import io.tabular.iceberg.connect.events.TransactionDataComplete;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -41,20 +42,20 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
-
-import io.tabular.iceberg.connect.events.TransactionDataComplete;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.connect.events.AvroUtil;
-import org.apache.iceberg.connect.events.CommitComplete;
 import org.apache.iceberg.connect.events.DataWritten;
 import org.apache.iceberg.connect.events.Event;
 import org.apache.iceberg.connect.events.PayloadType;
 import org.apache.iceberg.connect.events.StartCommit;
+import org.apache.iceberg.connect.events.TableReference;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
@@ -88,15 +89,16 @@ class CommitterImplTest {
   private static final String SOURCE_TOPIC = "source-topic-name";
   private static final TopicPartition SOURCE_TP0 = new TopicPartition(SOURCE_TOPIC, 0);
   private static final TopicPartition SOURCE_TP1 = new TopicPartition(SOURCE_TOPIC, 1);
-  // note: only partition=0 is assigned
   private static final Set<TopicPartition> ASSIGNED_SOURCE_TOPIC_PARTITIONS =
-      ImmutableSet.of(SOURCE_TP0);
+          ImmutableSet.of(SOURCE_TP0);
   private static final String CONNECTOR_NAME = "connector-name";
   private static final String TABLE_1_NAME = "db.tbl1";
   private static final TableIdentifier TABLE_1_IDENTIFIER = TableIdentifier.parse(TABLE_1_NAME);
+  private static final TableReference TABLE_1_REFERENCE =
+          TableReference.of(CATALOG_NAME, TABLE_1_IDENTIFIER);
   private static final String CONTROL_TOPIC = "control-topic-name";
   private static final TopicPartition CONTROL_TOPIC_PARTITION =
-      new TopicPartition(CONTROL_TOPIC, 0);
+          new TopicPartition(CONTROL_TOPIC, 0);
   private KafkaClientFactory kafkaClientFactory;
   private UUID producerId;
   private MockProducer<String, byte[]> producer;
@@ -106,13 +108,10 @@ class CommitterImplTest {
   @BeforeEach
   public void before() {
     admin = mock(Admin.class);
-
     producerId = UUID.randomUUID();
     producer = new MockProducer<>(false, new StringSerializer(), new ByteArraySerializer());
     producer.initTransactions();
-
     consumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
-
     kafkaClientFactory = mock(KafkaClientFactory.class);
     when(kafkaClientFactory.createConsumer(any())).thenReturn(consumer);
     when(kafkaClientFactory.createProducer(any())).thenReturn(Pair.of(producerId, producer));
@@ -133,17 +132,17 @@ class CommitterImplTest {
 
   private static IcebergSinkConfig makeConfig(int taskId) {
     return new IcebergSinkConfig(
-        ImmutableMap.of(
-            "name",
-            CONNECTOR_NAME,
-            "iceberg.catalog.catalog-impl",
-            "org.apache.iceberg.inmemory.InMemoryCatalog",
-            "iceberg.tables",
-            TABLE_1_NAME,
-            "iceberg.control.topic",
-            CONTROL_TOPIC,
-            IcebergSinkConfig.INTERNAL_TRANSACTIONAL_SUFFIX_PROP,
-            "-txn-" + UUID.randomUUID() + "-" + taskId));
+            ImmutableMap.of(
+                    "name",
+                    CONNECTOR_NAME,
+                    "iceberg.catalog.catalog-impl",
+                    "org.apache.iceberg.inmemory.InMemoryCatalog",
+                    "iceberg.tables",
+                    TABLE_1_NAME,
+                    "iceberg.control.topic",
+                    CONTROL_TOPIC,
+                    IcebergSinkConfig.INTERNAL_TRANSACTIONAL_SUFFIX_PROP,
+                    "-txn-" + UUID.randomUUID() + "-" + taskId));
   }
 
   private static final IcebergSinkConfig CONFIG = makeConfig(1);
@@ -156,23 +155,23 @@ class CommitterImplTest {
 
   private static DynConstructors.Ctor<CoordinatorKey> ctorCoordinatorKey() {
     return DynConstructors.builder(CoordinatorKey.class)
-        .hiddenImpl(
-            "org.apache.kafka.clients.admin.internals.CoordinatorKey",
-            FindCoordinatorRequest.CoordinatorType.class,
-            String.class)
-        .build();
+            .hiddenImpl(
+                    "org.apache.kafka.clients.admin.internals.CoordinatorKey",
+                    FindCoordinatorRequest.CoordinatorType.class,
+                    String.class)
+            .build();
   }
 
   private static DynConstructors.Ctor<ListConsumerGroupOffsetsResult>
-      ctorListConsumerGroupOffsetsResult() {
+  ctorListConsumerGroupOffsetsResult() {
     return DynConstructors.builder(ListConsumerGroupOffsetsResult.class)
-        .hiddenImpl("org.apache.kafka.clients.admin.ListConsumerGroupOffsetsResult", Map.class)
-        .build();
+            .hiddenImpl("org.apache.kafka.clients.admin.ListConsumerGroupOffsetsResult", Map.class)
+            .build();
   }
 
   private final CoordinatorKey coordinatorKey =
-      ctorCoordinatorKey()
-          .newInstance(FindCoordinatorRequest.CoordinatorType.GROUP, "fakeCoordinatorKey");
+          ctorCoordinatorKey()
+                  .newInstance(FindCoordinatorRequest.CoordinatorType.GROUP, "fakeCoordinatorKey");
 
   @SuppressWarnings("deprecation")
   private static ListConsumerGroupOffsetsOptions listOffsetResultMatcher() {
@@ -180,33 +179,30 @@ class CommitterImplTest {
   }
 
   private ListConsumerGroupOffsetsResult listConsumerGroupOffsetsResult(
-      Map<TopicPartition, Long> consumerOffsets) {
+          Map<TopicPartition, Long> consumerOffsets) {
     return ctorListConsumerGroupOffsetsResult()
-        .newInstance(
-            ImmutableMap.of(
-                coordinatorKey,
-                KafkaFuture.completedFuture(
-                    consumerOffsets.entrySet().stream()
-                        .collect(
-                            Collectors.toMap(
-                                Map.Entry::getKey, e -> new OffsetAndMetadata(e.getValue()))))));
+            .newInstance(
+                    ImmutableMap.of(
+                            coordinatorKey,
+                            KafkaFuture.completedFuture(
+                                    consumerOffsets.entrySet().stream()
+                                            .collect(
+                                                    Collectors.toMap(
+                                                            Map.Entry::getKey, e -> new OffsetAndMetadata(e.getValue()))))));
   }
 
   private void whenAdminListConsumerGroupOffsetsThenReturn(
-      Map<String, Map<TopicPartition, Long>> consumersOffsets) {
+          Map<String, Map<TopicPartition, Long>> consumersOffsets) {
     consumersOffsets.forEach(
-        (consumerGroup, consumerOffsets) -> {
-          when(admin.listConsumerGroupOffsets(eq(consumerGroup), listOffsetResultMatcher()))
-              .thenReturn(listConsumerGroupOffsetsResult(consumerOffsets));
-        });
+            (consumerGroup, consumerOffsets) -> {
+              when(admin.listConsumerGroupOffsets(eq(consumerGroup), listOffsetResultMatcher()))
+                      .thenReturn(listConsumerGroupOffsetsResult(consumerOffsets));
+            });
   }
 
   private static class NoOpCoordinatorThreadFactory implements CoordinatorThreadFactory {
-    int numTimesCalled = 0;
-
     @Override
     public Optional<CoordinatorThread> create(SinkTaskContext context, IcebergSinkConfig config) {
-      numTimesCalled += 1;
       CoordinatorThread mockThread = mock(CoordinatorThread.class);
       Mockito.doNothing().when(mockThread).start();
       Mockito.doNothing().when(mockThread).terminate();
@@ -230,21 +226,19 @@ class CommitterImplTest {
   }
 
   private static <F extends ContentFile<F>> void assertSameContentFiles(
-      List<F> actual, List<F> expected) {
+          List<F> actual, List<F> expected) {
     assertThat(actual.stream().map(CommitterImplTest::toPath).collect(Collectors.toList()))
-        .containsExactlyElementsOf(
-            expected.stream().map(CommitterImplTest::toPath).collect(Collectors.toList()));
+            .containsExactlyElementsOf(
+                    expected.stream().map(CommitterImplTest::toPath).collect(Collectors.toList()));
   }
 
   private void assertDataWritten(
-      ProducerRecord<String, byte[]> producerRecord,
-      UUID expectedProducerId,
-      UUID expectedCommitId,
-      TableIdentifier expectedTableIdentifier,
-      List<DataFile> expectedDataFiles,
-      List<DeleteFile> expectedDeleteFiles) {
-    assertThat(producerRecord.key()).isEqualTo(expectedProducerId.toString());
-
+          ProducerRecord<String, byte[]> producerRecord,
+          UUID expectedCommitId,
+          TableIdentifier expectedTableIdentifier,
+          List<DataFile> expectedDataFiles,
+          List<DeleteFile> expectedDeleteFiles) {
+    assertThat(producerRecord.key()).isEqualTo(producerId.toString());
     Event event = AvroUtil.decode(producerRecord.value());
     assertThat(event.type()).isEqualTo(PayloadType.DATA_WRITTEN);
     assertThat(event.payload()).isInstanceOf(DataWritten.class);
@@ -257,12 +251,11 @@ class CommitterImplTest {
   }
 
   private void assertDataComplete(
-      ProducerRecord<String, byte[]> producerRecord,
-      UUID expectedProducerId,
-      UUID expectedCommitId,
-      Map<TopicPartition, Pair<Long, OffsetDateTime>> expectedAssignments,
-      Map<TopicPartition, Long> expectedTxIds) {
-    assertThat(producerRecord.key()).isEqualTo(expectedProducerId.toString());
+          ProducerRecord<String, byte[]> producerRecord,
+          UUID expectedCommitId,
+          Map<TopicPartition, Pair<Long, OffsetDateTime>> expectedAssignments,
+          List<TableTopicPartitionTransaction> expectedTxIds) {
+    assertThat(producerRecord.key()).isEqualTo(producerId.toString());
 
     Event event = AvroUtil.decode(producerRecord.value());
     assertThat(event.type()).isEqualTo(PayloadType.DATA_COMPLETE);
@@ -271,59 +264,65 @@ class CommitterImplTest {
     assertThat(commitReadyPayload.commitId()).isEqualTo(expectedCommitId);
     assertThat(
             commitReadyPayload.assignments().stream()
-                .map(
-                    x ->
-                        Pair.of(
-                            new TopicPartition(x.topic(), x.partition()),
-                            Pair.of(x.offset(), x.timestamp())))
-                .collect(Collectors.toList()))
-        .isEqualTo(
-            expectedAssignments.entrySet().stream()
-                .map(e -> Pair.of(e.getKey(), e.getValue()))
-                .collect(Collectors.toList()));
+                    .map(
+                            x ->
+                                    Pair.of(
+                                            new TopicPartition(x.topic(), x.partition()),
+                                            Pair.of(x.offset(), x.timestamp())))
+                    .collect(Collectors.toList()))
+            .containsExactlyInAnyOrderElementsOf(
+                    expectedAssignments.entrySet().stream()
+                            .map(e -> Pair.of(e.getKey(), e.getValue()))
+                            .collect(Collectors.toList()));
 
-    assertThat(
-            commitReadyPayload.txIds().stream()
-                .map(
-                    x ->
-                        Pair.of(
-                            new TopicPartition(x.topic(), x.partition()), x.txId()))
-                .collect(Collectors.toList()))
-        .isEqualTo(
-            expectedTxIds.entrySet().stream()
-                .map(e -> Pair.of(e.getKey(), e.getValue()))
-                .collect(Collectors.toList()));
+    assertThat(commitReadyPayload.tableTxIds()).hasSize(expectedTxIds.size());
+    for (int i = 0; i < expectedTxIds.size(); i++) {
+      TableTopicPartitionTransaction actual = commitReadyPayload.tableTxIds().get(i);
+      TableTopicPartitionTransaction expected = expectedTxIds.get(i);
+      assertThat(actual.topic()).isEqualTo(expected.topic());
+      assertThat(actual.partition()).isEqualTo(expected.partition());
+      assertThat(actual.tableIdentifier()).isEqualTo(expected.tableIdentifier());
+      assertThat(actual.txId()).isEqualTo(expected.txId());
+    }
   }
 
   private OffsetDateTime offsetDateTime(Long ms) {
-   return OffsetDateTime.ofInstant(Instant.ofEpochMilli(ms), ZoneOffset.UTC);
+    return ms == null ? null : OffsetDateTime.ofInstant(Instant.ofEpochMilli(ms), ZoneOffset.UTC);
+  }
+    /**
+     * Creates a mock DataFile with a fixed size and record count.
+     * This is used to simulate the data files that would be written during a commit.
+     *
+     * @param path the path of the data file
+     * @return a mock DataFile
+     */
+  private DataFile createDataFile(String path) {
+    return DataFiles.builder(PartitionSpec.unpartitioned())
+            .withPath(path)
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .build();
   }
 
   @Test
-  public void
-      testShouldRewindOffsetsToStableControlGroupConsumerOffsetsForAssignedPartitionsOnConstruction()
+  public void testShouldRewindOffsetsToStableControlGroupConsumerOffsetsForAssignedPartitionsOnConstruction()
           throws IOException {
     SinkTaskContext mockContext = mockContext();
-
     ArgumentCaptor<Map<TopicPartition, Long>> offsetArgumentCaptor =
-        ArgumentCaptor.forClass(Map.class);
-
+            ArgumentCaptor.forClass(Map.class);
     IcebergSinkConfig config = makeConfig(1);
-
     NoOpCoordinatorThreadFactory coordinatorThreadFactory = new NoOpCoordinatorThreadFactory();
-
     whenAdminListConsumerGroupOffsetsThenReturn(
-        ImmutableMap.of(
-            config.controlGroupId(), ImmutableMap.of(SOURCE_TP0, 110L, SOURCE_TP1, 100L),
-            config.connectGroupId(), ImmutableMap.of(SOURCE_TP0, 90L, SOURCE_TP1, 80L)));
+            ImmutableMap.of(
+                    config.controlGroupId(), ImmutableMap.of(SOURCE_TP0, 110L, SOURCE_TP1, 100L),
+                    config.connectGroupId(), ImmutableMap.of(SOURCE_TP0, 90L, SOURCE_TP1, 80L)));
 
     try (CommitterImpl ignored =
-        new CommitterImpl(mockContext, config, kafkaClientFactory, coordinatorThreadFactory)) {
+                 new CommitterImpl(mockContext, config, kafkaClientFactory, coordinatorThreadFactory)) {
       initConsumer();
-
       verify(mockContext).offset(offsetArgumentCaptor.capture());
       assertThat(offsetArgumentCaptor.getAllValues())
-          .isEqualTo(ImmutableList.of(ImmutableMap.of(SOURCE_TP0, 110L)));
+              .isEqualTo(ImmutableList.of(ImmutableMap.of(SOURCE_TP0, 110L)));
     }
   }
 
@@ -331,93 +330,23 @@ class CommitterImplTest {
   public void testCommitShouldThrowExceptionIfCoordinatorIsTerminated() throws IOException {
     SinkTaskContext mockContext = mockContext();
     IcebergSinkConfig config = makeConfig(0);
-
     whenAdminListConsumerGroupOffsetsThenReturn(
-        ImmutableMap.of(
-            config.controlGroupId(), ImmutableMap.of(SOURCE_TP0, 110L, SOURCE_TP1, 100L)));
-
+            ImmutableMap.of(
+                    config.controlGroupId(), ImmutableMap.of(SOURCE_TP0, 110L, SOURCE_TP1, 100L)));
     TerminatedCoordinatorThreadFactory coordinatorThreadFactory =
-        new TerminatedCoordinatorThreadFactory();
-
+            new TerminatedCoordinatorThreadFactory();
     CommittableSupplier committableSupplier =
-        () -> {
-          throw new NotImplementedException("Should not be called");
-        };
+            () -> {
+              throw new NotImplementedException("Should not be called");
+            };
 
     try (CommitterImpl committerImpl =
-        new CommitterImpl(mockContext, config, kafkaClientFactory, coordinatorThreadFactory)) {
+                 new CommitterImpl(mockContext, config, kafkaClientFactory, coordinatorThreadFactory)) {
       initConsumer();
       Committer committer = committerImpl;
-
       assertThatThrownBy(() -> committer.commit(committableSupplier))
-          .isInstanceOf(RuntimeException.class)
-          .hasMessage("Coordinator unexpectedly terminated");
-
-      assertThat(producer.history()).isEmpty();
-      assertThat(producer.consumerGroupOffsetsHistory()).isEmpty();
-    }
-  }
-
-  @Test
-  public void testCommitShouldDoNothingIfThereAreNoMessages() throws IOException {
-    SinkTaskContext mockContext = mockContext();
-
-    NoOpCoordinatorThreadFactory coordinatorThreadFactory = new NoOpCoordinatorThreadFactory();
-
-    whenAdminListConsumerGroupOffsetsThenReturn(
-        ImmutableMap.of(
-            CONFIG.controlGroupId(), ImmutableMap.of(SOURCE_TP0, 110L, SOURCE_TP1, 100L)));
-
-    CommittableSupplier committableSupplier =
-        () -> {
-          throw new NotImplementedException("Should not be called");
-        };
-
-    try (CommitterImpl committerImpl =
-        new CommitterImpl(mockContext, CONFIG, kafkaClientFactory, coordinatorThreadFactory)) {
-      initConsumer();
-      Committer committer = committerImpl;
-
-      committer.commit(committableSupplier);
-
-      assertThat(producer.history()).isEmpty();
-      assertThat(producer.consumerGroupOffsetsHistory()).isEmpty();
-    }
-  }
-
-  @Test
-  public void testCommitShouldDoNothingIfThereIsNoCommitRequestMessage() throws IOException {
-    SinkTaskContext mockContext = mockContext();
-
-    NoOpCoordinatorThreadFactory coordinatorThreadFactory = new NoOpCoordinatorThreadFactory();
-
-    whenAdminListConsumerGroupOffsetsThenReturn(
-        ImmutableMap.of(
-            CONFIG.controlGroupId(), ImmutableMap.of(SOURCE_TP0, 110L, SOURCE_TP1, 100L)));
-
-    CommittableSupplier committableSupplier =
-        () -> {
-          throw new NotImplementedException("Should not be called");
-        };
-
-    try (CommitterImpl committerImpl =
-        new CommitterImpl(mockContext, CONFIG, kafkaClientFactory, coordinatorThreadFactory)) {
-      initConsumer();
-      Committer committer = committerImpl;
-
-      consumer.addRecord(
-          new ConsumerRecord<>(
-              CONTROL_TOPIC,
-              CONTROL_TOPIC_PARTITION.partition(),
-              0,
-              UUID.randomUUID().toString(),
-              AvroUtil.encode(
-                  new Event(
-                      CONFIG.controlGroupId(),
-                      new CommitComplete(UUID.randomUUID(), offsetDateTime(100L))))));
-
-      committer.commit(committableSupplier);
-
+              .isInstanceOf(RuntimeException.class)
+              .hasMessage("Coordinator unexpectedly terminated");
       assertThat(producer.history()).isEmpty();
       assertThat(producer.consumerGroupOffsetsHistory()).isEmpty();
     }
@@ -426,113 +355,103 @@ class CommitterImplTest {
   @Test
   public void testCommitShouldRespondToCommitRequest() throws IOException {
     SinkTaskContext mockContext = mockContext();
-
     NoOpCoordinatorThreadFactory coordinatorThreadFactory = new NoOpCoordinatorThreadFactory();
     UUID commitId = UUID.randomUUID();
-
     whenAdminListConsumerGroupOffsetsThenReturn(
-        ImmutableMap.of(
-            CONFIG.controlGroupId(), ImmutableMap.of(SOURCE_TP0, 110L, SOURCE_TP1, 100L)));
+            ImmutableMap.of(
+                    CONFIG.controlGroupId(), ImmutableMap.of(SOURCE_TP0, 110L, SOURCE_TP1, 100L)));
 
-    List<DataFile> dataFiles = ImmutableList.of(createDataFile());
+    List<DataFile> dataFiles = ImmutableList.of(createDataFile("/path/to/data-1.parquet"));
     List<DeleteFile> deleteFiles = ImmutableList.of();
     Types.StructType partitionStruct = Types.StructType.of();
     Map<TopicPartition, Offset> sourceOffsets = ImmutableMap.of(SOURCE_TP0, new Offset(100L, 200L));
-    Map<TopicPartition, Long> sourceTxIds = ImmutableMap.of(SOURCE_TP0, 100L);
+
+    List<TableTopicPartitionTransaction> sourceTxIds =
+            ImmutableList.of(
+                    new TableTopicPartitionTransaction(
+                            SOURCE_TP0.topic(),
+                            SOURCE_TP0.partition(),
+                            CATALOG_NAME,
+                            TABLE_1_IDENTIFIER,
+                            100L));
+
     CommittableSupplier committableSupplier =
-        () ->
-            new Committable(
-                sourceOffsets,
-                sourceTxIds,
-                ImmutableList.of(
-                    new WriterResult(TABLE_1_IDENTIFIER, dataFiles, deleteFiles, partitionStruct)));
+            () ->
+                    new Committable(
+                            sourceOffsets,
+                            sourceTxIds,
+                            ImmutableList.of(
+                                    new WriterResult(TABLE_1_IDENTIFIER, dataFiles, deleteFiles, partitionStruct)));
 
     try (CommitterImpl committerImpl =
-        new CommitterImpl(mockContext, CONFIG, kafkaClientFactory, coordinatorThreadFactory)) {
+                 new CommitterImpl(mockContext, CONFIG, kafkaClientFactory, coordinatorThreadFactory)) {
       initConsumer();
       Committer committer = committerImpl;
 
       consumer.addRecord(
-          new ConsumerRecord<>(
-              CONTROL_TOPIC_PARTITION.topic(),
-              CONTROL_TOPIC_PARTITION.partition(),
-              0,
-              UUID.randomUUID().toString(),
-              AvroUtil.encode(
-                  new Event(
-                      CONFIG.controlGroupId(),
-                      new StartCommit(commitId)))));
+              new ConsumerRecord<>(
+                      CONTROL_TOPIC_PARTITION.topic(),
+                      CONTROL_TOPIC_PARTITION.partition(),
+                      0,
+                      UUID.randomUUID().toString(),
+                      AvroUtil.encode(new Event(CONFIG.controlGroupId(), new StartCommit(commitId)))));
 
       committer.commit(committableSupplier);
 
       assertThat(producer.transactionCommitted()).isTrue();
       assertThat(producer.history()).hasSize(2);
       assertDataWritten(
-          producer.history().get(0),
-          producerId,
-          commitId,
-          TABLE_1_IDENTIFIER,
-          dataFiles,
-          deleteFiles);
+              producer.history().get(0), commitId, TABLE_1_IDENTIFIER, dataFiles, deleteFiles);
       assertDataComplete(
-          producer.history().get(1),
-          producerId,
-          commitId,
-          ImmutableMap.of(SOURCE_TP0, Pair.of(100L, offsetDateTime(200L))),
-          ImmutableMap.of(SOURCE_TP0, 100L));
+              producer.history().get(1),
+              commitId,
+              ImmutableMap.of(SOURCE_TP0, Pair.of(100L, offsetDateTime(200L))),
+              sourceTxIds);
 
       assertThat(producer.consumerGroupOffsetsHistory()).hasSize(2);
       Map<TopicPartition, OffsetAndMetadata> expectedConsumerOffset =
-          ImmutableMap.of(SOURCE_TP0, new OffsetAndMetadata(100L));
+              ImmutableMap.of(SOURCE_TP0, new OffsetAndMetadata(100L));
       assertThat(producer.consumerGroupOffsetsHistory().get(0))
-          .isEqualTo(ImmutableMap.of(CONFIG.controlGroupId(), expectedConsumerOffset));
+              .isEqualTo(ImmutableMap.of(CONFIG.controlGroupId(), expectedConsumerOffset));
       assertThat(producer.consumerGroupOffsetsHistory().get(1))
-          .isEqualTo(ImmutableMap.of(CONFIG.connectGroupId(), expectedConsumerOffset));
+              .isEqualTo(ImmutableMap.of(CONFIG.connectGroupId(), expectedConsumerOffset));
     }
   }
 
   @Test
   public void testCommitWhenCommittableIsEmpty() throws IOException {
     SinkTaskContext mockContext = mockContext();
-
     NoOpCoordinatorThreadFactory coordinatorThreadFactory = new NoOpCoordinatorThreadFactory();
-
     UUID commitId = UUID.randomUUID();
-
     whenAdminListConsumerGroupOffsetsThenReturn(
-        ImmutableMap.of(
-            CONFIG.controlGroupId(), ImmutableMap.of(SOURCE_TP0, 110L, SOURCE_TP1, 100L)));
+            ImmutableMap.of(
+                    CONFIG.controlGroupId(), ImmutableMap.of(SOURCE_TP0, 110L, SOURCE_TP1, 100L)));
 
     CommittableSupplier committableSupplier =
-        () -> new Committable(ImmutableMap.of(), ImmutableMap.of(), ImmutableList.of());
+            () -> new Committable(ImmutableMap.of(), ImmutableList.of(), ImmutableList.of());
 
     try (CommitterImpl committerImpl =
-        new CommitterImpl(mockContext, CONFIG, kafkaClientFactory, coordinatorThreadFactory)) {
+                 new CommitterImpl(mockContext, CONFIG, kafkaClientFactory, coordinatorThreadFactory)) {
       initConsumer();
       Committer committer = committerImpl;
 
       consumer.addRecord(
-          new ConsumerRecord<>(
-              CONTROL_TOPIC_PARTITION.topic(),
-              CONTROL_TOPIC_PARTITION.partition(),
-              0,
-              UUID.randomUUID().toString(),
-              AvroUtil.encode(
-                  new Event(
-                      CONFIG.controlGroupId(),
-                      new StartCommit(commitId)))));
-
+              new ConsumerRecord<>(
+                      CONTROL_TOPIC_PARTITION.topic(),
+                      CONTROL_TOPIC_PARTITION.partition(),
+                      0,
+                      UUID.randomUUID().toString(),
+                      AvroUtil.encode(new Event(CONFIG.controlGroupId(), new StartCommit(commitId)))));
 
       committer.commit(committableSupplier);
 
       assertThat(producer.transactionCommitted()).isTrue();
       assertThat(producer.history()).hasSize(1);
       assertDataComplete(
-          producer.history().get(0),
-          producerId,
-          commitId,
-          ImmutableMap.of(SOURCE_TP0, Pair.of(null, null)),
-          ImmutableMap.of());
+              producer.history().get(0),
+              commitId,
+              ImmutableMap.of(SOURCE_TP0, Pair.of(null, null)),
+              ImmutableList.of());
 
       assertThat(producer.consumerGroupOffsetsHistory()).hasSize(0);
     }
@@ -541,75 +460,70 @@ class CommitterImplTest {
   @Test
   public void testCommitShouldCommitOffsetsOnlyForPartitionsWeMadeProgressOn() throws IOException {
     SinkTaskContext mockContext = mockContext();
-
     NoOpCoordinatorThreadFactory coordinatorThreadFactory = new NoOpCoordinatorThreadFactory();
-
     TopicPartition sourceTp0 = new TopicPartition(SOURCE_TOPIC, 0);
     TopicPartition sourceTp1 = new TopicPartition(SOURCE_TOPIC, 1);
     Set<TopicPartition> sourceTopicPartitions = ImmutableSet.of(sourceTp0, sourceTp1);
-
     when(mockContext.assignment()).thenReturn(sourceTopicPartitions);
-
     UUID commitId = UUID.randomUUID();
-
     whenAdminListConsumerGroupOffsetsThenReturn(
-        ImmutableMap.of(
-            CONFIG.controlGroupId(), ImmutableMap.of(SOURCE_TP0, 110L, SOURCE_TP1, 100L)));
+            ImmutableMap.of(
+                    CONFIG.controlGroupId(), ImmutableMap.of(SOURCE_TP0, 110L, SOURCE_TP1, 100L)));
 
-    List<DataFile> dataFiles = ImmutableList.of(createDataFile());
+    List<DataFile> dataFiles = ImmutableList.of(createDataFile("/path/to/data-2.parquet"));
     List<DeleteFile> deleteFiles = ImmutableList.of();
     Types.StructType partitionStruct = Types.StructType.of();
+
+    List<TableTopicPartitionTransaction> sourceTxIds =
+            ImmutableList.of(
+                    new TableTopicPartitionTransaction(
+                            SOURCE_TP0.topic(),
+                            SOURCE_TP0.partition(),
+                            CATALOG_NAME,
+                            TABLE_1_IDENTIFIER,
+                            100L));
+
     CommittableSupplier committableSupplier =
-        () ->
-            new Committable(
-                ImmutableMap.of(sourceTp1, new Offset(100L, 200L)),
-                ImmutableMap.of(sourceTp1, 999L),
-                ImmutableList.of(
-                    new WriterResult(TABLE_1_IDENTIFIER, dataFiles, deleteFiles, partitionStruct)));
+            () ->
+                    new Committable(
+                            ImmutableMap.of(sourceTp1, new Offset(100L, 200L)),
+                            sourceTxIds,
+                            ImmutableList.of(
+                                    new WriterResult(TABLE_1_IDENTIFIER, dataFiles, deleteFiles, partitionStruct)));
 
     try (CommitterImpl committerImpl =
-        new CommitterImpl(mockContext, CONFIG, kafkaClientFactory, coordinatorThreadFactory)) {
+                 new CommitterImpl(mockContext, CONFIG, kafkaClientFactory, coordinatorThreadFactory)) {
       initConsumer();
       Committer committer = committerImpl;
 
       consumer.addRecord(
-          new ConsumerRecord<>(
-              CONTROL_TOPIC_PARTITION.topic(),
-              CONTROL_TOPIC_PARTITION.partition(),
-              0,
-              UUID.randomUUID().toString(),
-              AvroUtil.encode(
-                  new Event(
-                      CONFIG.controlGroupId(),
-                      new StartCommit(commitId)))));
+              new ConsumerRecord<>(
+                      CONTROL_TOPIC_PARTITION.topic(),
+                      CONTROL_TOPIC_PARTITION.partition(),
+                      0,
+                      UUID.randomUUID().toString(),
+                      AvroUtil.encode(new Event(CONFIG.controlGroupId(), new StartCommit(commitId)))));
 
       committer.commit(committableSupplier);
 
       assertThat(producer.transactionCommitted()).isTrue();
       assertThat(producer.history()).hasSize(2);
       assertDataWritten(
-          producer.history().get(0),
-          producerId,
-          commitId,
-          TABLE_1_IDENTIFIER,
-          dataFiles,
-          deleteFiles);
+              producer.history().get(0), commitId, TABLE_1_IDENTIFIER, dataFiles, deleteFiles);
       assertDataComplete(
-          producer.history().get(1),
-          producerId,
-          commitId,
-          ImmutableMap.of(
-              sourceTp0, Pair.of(null, null),
-              sourceTp1, Pair.of(100L, offsetDateTime(200L))),
-              ImmutableMap.of(sourceTp1, 999L));
+              producer.history().get(1),
+              commitId,
+              ImmutableMap.of(
+                      sourceTp0, Pair.of(null, null), sourceTp1, Pair.of(100L, offsetDateTime(200L))),
+              sourceTxIds);
 
       assertThat(producer.consumerGroupOffsetsHistory()).hasSize(2);
       Map<TopicPartition, OffsetAndMetadata> expectedConsumerOffset =
-          ImmutableMap.of(sourceTp1, new OffsetAndMetadata(100L));
+              ImmutableMap.of(sourceTp1, new OffsetAndMetadata(100L));
       assertThat(producer.consumerGroupOffsetsHistory().get(0))
-          .isEqualTo(ImmutableMap.of(CONFIG.controlGroupId(), expectedConsumerOffset));
+              .isEqualTo(ImmutableMap.of(CONFIG.controlGroupId(), expectedConsumerOffset));
       assertThat(producer.consumerGroupOffsetsHistory().get(1))
-          .isEqualTo(ImmutableMap.of(CONFIG.connectGroupId(), expectedConsumerOffset));
+              .isEqualTo(ImmutableMap.of(CONFIG.connectGroupId(), expectedConsumerOffset));
     }
   }
 }

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CoordinatorTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CoordinatorTest.java
@@ -21,7 +21,7 @@ package io.tabular.iceberg.connect.channel;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-import io.tabular.iceberg.connect.events.TopicPartitionTransaction;
+import io.tabular.iceberg.connect.events.TableTopicPartitionTransaction; // ADDED
 import io.tabular.iceberg.connect.events.TransactionDataComplete;
 import io.tabular.iceberg.connect.fixtures.EventTestUtil;
 import java.time.Instant;
@@ -42,6 +42,7 @@ import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.connect.events.AvroUtil;
 import org.apache.iceberg.connect.events.CommitComplete;
 import org.apache.iceberg.connect.events.CommitToTable;
@@ -66,20 +67,26 @@ import org.junit.jupiter.api.Test;
 
 public class CoordinatorTest extends ChannelTestBase {
 
+  // The property name for max-tx-id has a typo in the original test, correcting it here
+  private static final String MAX_TX_ID_PROP = "txid-max";
+
   @Test
   public void testCommitAppend() {
     Assertions.assertEquals(0, ImmutableList.copyOf(table.snapshots().iterator()).size());
 
-    List<TopicPartitionTransaction> transactionsProcessed =
-            ImmutableList.of(new TopicPartitionTransaction("topic", 1, 100L));
+    // CHANGED: Use the new transaction object, including the table reference
+    TableReference tableRef = TableReference.of("catalog", TABLE_IDENTIFIER);
+    List<TableTopicPartitionTransaction> transactionsProcessed =
+            ImmutableList.of(new TableTopicPartitionTransaction("topic", 1, "catalog", TABLE_IDENTIFIER, 100L));
+
     OffsetDateTime ts = OffsetDateTime.ofInstant(Instant.now(), ZoneOffset.UTC);
     UUID commitId =
-        coordinatorTest(ImmutableList.of(EventTestUtil.createDataFile()), ImmutableList.of(), ts, transactionsProcessed);
+            coordinatorTest(ImmutableList.of(EventTestUtil.createDataFile()), ImmutableList.of(), ts, transactionsProcessed);
     table.refresh();
 
     assertThat(producer.history()).hasSize(3);
     assertThat(consumer.committed(ImmutableSet.of(CTL_TOPIC_PARTITION)))
-        .isEqualTo(ImmutableMap.of(CTL_TOPIC_PARTITION, new OffsetAndMetadata(3L)));
+            .isEqualTo(ImmutableMap.of(CTL_TOPIC_PARTITION, new OffsetAndMetadata(3L)));
     assertCommitTable(1, commitId, ts);
     assertCommitComplete(2, commitId, ts);
 
@@ -95,32 +102,36 @@ public class CoordinatorTest extends ChannelTestBase {
     Assertions.assertEquals(commitId.toString(), summary.get(COMMIT_ID_SNAPSHOT_PROP));
     Assertions.assertEquals("{\"0\":3}", summary.get(OFFSETS_SNAPSHOT_PROP));
     Assertions.assertEquals(
-        Long.toString(ts.toInstant().toEpochMilli()), summary.get(VTTS_SNAPSHOT_PROP));
-    Assertions.assertEquals(transactionsProcessed.get(0).txId() - 1, Long.valueOf(summary.get(TX_ID_VALID_THROUGH_PROP)));
-    Assertions.assertEquals(transactionsProcessed.get(0).txId(), Long.valueOf(summary.get(MAX_TX_ID__PROP)));
+            Long.toString(ts.toInstant().toEpochMilli()), summary.get(VTTS_SNAPSHOT_PROP));
+    Assertions.assertEquals(99L, Long.valueOf(summary.get(TX_ID_VALID_THROUGH_PROP)));
+    Assertions.assertEquals(100L, Long.valueOf(summary.get(MAX_TX_ID_PROP)));
   }
 
   @Test
   public void testCommitDelta() {
-    List<TopicPartitionTransaction> transactionsProcessed =
-            ImmutableList.of(new TopicPartitionTransaction("topic", 1, 100L),
-            new TopicPartitionTransaction("topic", 2, 102L),
-            new TopicPartitionTransaction("topic", 3, 101L),
-            new TopicPartitionTransaction("topic", 3, 102L),
-            new TopicPartitionTransaction("topic", 3, 100L),
-            new TopicPartitionTransaction("topic", 3, 103L),
-            new TopicPartitionTransaction("topic", 4, 104L));
+    // CHANGED: Use the new transaction object
+    TableReference tableRef = TableReference.of("catalog", TABLE_IDENTIFIER);
+    List<TableTopicPartitionTransaction> transactionsProcessed =
+            ImmutableList.of(
+                    new TableTopicPartitionTransaction("topic", 1, "catalog", TABLE_IDENTIFIER, 100L),
+                    new TableTopicPartitionTransaction("topic", 2, "catalog", TABLE_IDENTIFIER, 102L),
+                    new TableTopicPartitionTransaction("topic", 3, "catalog", TABLE_IDENTIFIER, 101L),
+                    new TableTopicPartitionTransaction("topic", 3, "catalog", TABLE_IDENTIFIER, 102L),
+                    new TableTopicPartitionTransaction("topic", 3, "catalog", TABLE_IDENTIFIER, 100L),
+                    new TableTopicPartitionTransaction("topic", 3, "catalog", TABLE_IDENTIFIER, 103L),
+                    new TableTopicPartitionTransaction("topic", 4, "catalog", TABLE_IDENTIFIER, 104L));
+
     OffsetDateTime ts = OffsetDateTime.ofInstant(Instant.now(), ZoneOffset.UTC);
     UUID commitId =
-        coordinatorTest(
-            ImmutableList.of(EventTestUtil.createDataFile()),
-            ImmutableList.of(EventTestUtil.createDeleteFile()),
-            ts,
-            transactionsProcessed);
+            coordinatorTest(
+                    ImmutableList.of(EventTestUtil.createDataFile()),
+                    ImmutableList.of(EventTestUtil.createDeleteFile()),
+                    ts,
+                    transactionsProcessed);
 
     assertThat(producer.history()).hasSize(3);
     assertThat(consumer.committed(ImmutableSet.of(CTL_TOPIC_PARTITION)))
-        .isEqualTo(ImmutableMap.of(CTL_TOPIC_PARTITION, new OffsetAndMetadata(3L)));
+            .isEqualTo(ImmutableMap.of(CTL_TOPIC_PARTITION, new OffsetAndMetadata(3L)));
     assertCommitTable(1, commitId, ts);
     assertCommitComplete(2, commitId, ts);
 
@@ -136,9 +147,9 @@ public class CoordinatorTest extends ChannelTestBase {
     Assertions.assertEquals(commitId.toString(), summary.get(COMMIT_ID_SNAPSHOT_PROP));
     Assertions.assertEquals("{\"0\":3}", summary.get(OFFSETS_SNAPSHOT_PROP));
     Assertions.assertEquals(
-        Long.toString(ts.toInstant().toEpochMilli()), summary.get(VTTS_SNAPSHOT_PROP));
+            Long.toString(ts.toInstant().toEpochMilli()), summary.get(VTTS_SNAPSHOT_PROP));
     Assertions.assertEquals(99L, Long.valueOf(summary.get(TX_ID_VALID_THROUGH_PROP)));
-    Assertions.assertEquals(104L, Long.valueOf(summary.get(MAX_TX_ID__PROP)));
+    Assertions.assertEquals(104L, Long.valueOf(summary.get(MAX_TX_ID_PROP)));
   }
 
   @Test
@@ -148,7 +159,7 @@ public class CoordinatorTest extends ChannelTestBase {
 
     assertThat(producer.history()).hasSize(2);
     assertThat(consumer.committed(ImmutableSet.of(CTL_TOPIC_PARTITION)))
-        .isEqualTo(ImmutableMap.of(CTL_TOPIC_PARTITION, new OffsetAndMetadata(3L)));
+            .isEqualTo(ImmutableMap.of(CTL_TOPIC_PARTITION, new OffsetAndMetadata(3L)));
     assertCommitComplete(1, commitId, ts);
 
     List<Snapshot> snapshots = ImmutableList.copyOf(table.snapshots());
@@ -159,25 +170,25 @@ public class CoordinatorTest extends ChannelTestBase {
   public void testCommitError() {
     // this spec isn't registered with the table
     PartitionSpec badPartitionSpec =
-        PartitionSpec.builderFor(SCHEMA).withSpecId(1).identity("id").build();
+            PartitionSpec.builderFor(SCHEMA).withSpecId(1).identity("id").build();
     DataFile badDataFile =
-        DataFiles.builder(badPartitionSpec)
-            .withPath(UUID.randomUUID() + ".parquet")
-            .withFormat(FileFormat.PARQUET)
-            .withFileSizeInBytes(100L)
-            .withRecordCount(5)
-            .build();
+            DataFiles.builder(badPartitionSpec)
+                    .withPath(UUID.randomUUID() + ".parquet")
+                    .withFormat(FileFormat.PARQUET)
+                    .withFileSizeInBytes(100L)
+                    .withRecordCount(5)
+                    .build();
 
     coordinatorTest(
-        ImmutableList.of(badDataFile),
-        ImmutableList.of(),
-        OffsetDateTime.ofInstant(Instant.ofEpochMilli(0L), ZoneOffset.UTC),
-        ImmutableList.of());
+            ImmutableList.of(badDataFile),
+            ImmutableList.of(),
+            OffsetDateTime.ofInstant(Instant.ofEpochMilli(0L), ZoneOffset.UTC),
+            ImmutableList.of());
 
     // no commit messages sent
     assertThat(producer.history()).hasSize(1);
     assertThat(consumer.committed(ImmutableSet.of(CTL_TOPIC_PARTITION)))
-        .isEqualTo(ImmutableMap.of());
+            .isEqualTo(ImmutableMap.of());
 
     List<Snapshot> snapshots = ImmutableList.copyOf(table.snapshots());
     Assertions.assertEquals(0, snapshots.size());
@@ -185,34 +196,37 @@ public class CoordinatorTest extends ChannelTestBase {
 
   @Test
   public void testShouldDeduplicateDataFilesBeforeAppending() {
-    List<TopicPartitionTransaction> transactionsProcessed =
-            ImmutableList.of(new TopicPartitionTransaction("topic", 1, 100L));
+    // CHANGED: Use the new transaction object
+    TableReference tableRef = TableReference.of("catalog", TableIdentifier.of("db", "tbl"));
+    List<TableTopicPartitionTransaction> transactionsProcessed =
+            ImmutableList.of(new TableTopicPartitionTransaction("topic", 1, "catalog", TABLE_IDENTIFIER, 100L));
+
     OffsetDateTime ts = OffsetDateTime.ofInstant(Instant.now(), ZoneOffset.UTC);
     DataFile dataFile = EventTestUtil.createDataFile();
 
     UUID commitId =
-        coordinatorTest(
-            currentCommitId -> {
-              Event commitResponse =
-                  new Event(
-                      config.controlGroupId(),
-                      new DataWritten(
-                          StructType.of(),
-                          currentCommitId,
-                          new TableReference("catalog", ImmutableList.of("db"), "tbl"),
-                          ImmutableList.of(dataFile, dataFile), // duplicated data files
-                          ImmutableList.of()));
+            coordinatorTest(
+                    currentCommitId -> {
+                      Event commitResponse =
+                              new Event(
+                                      config.controlGroupId(),
+                                      new DataWritten(
+                                              StructType.of(),
+                                              currentCommitId,
+                                              tableRef,
+                                              ImmutableList.of(dataFile, dataFile), // duplicated data files
+                                              ImmutableList.of()));
 
-              return ImmutableList.of(
-                  commitResponse,
-                  commitResponse, // duplicate commit response
-                  new Event(
-                      config.controlGroupId(),
-                      new TransactionDataComplete(
-                          currentCommitId,
-                          ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L, ts)),
-                          transactionsProcessed)));
-            });
+                      return ImmutableList.of(
+                              commitResponse,
+                              commitResponse, // duplicate commit response
+                              new Event(
+                                      config.controlGroupId(),
+                                      new TransactionDataComplete(
+                                              currentCommitId,
+                                              ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L, ts)),
+                                              transactionsProcessed)));
+                    });
 
     assertCommitTable(1, commitId, ts);
     assertCommitComplete(2, commitId, ts);
@@ -225,8 +239,8 @@ public class CoordinatorTest extends ChannelTestBase {
     Assertions.assertEquals(1, ImmutableList.copyOf(snapshot.addedDataFiles(table.io())).size());
     Assertions.assertEquals(0, ImmutableList.copyOf(snapshot.addedDeleteFiles(table.io())).size());
     Map<String, String> summary = snapshot.summary();
-    Assertions.assertEquals(transactionsProcessed.get(0).txId() - 1, Long.valueOf(summary.get(TX_ID_VALID_THROUGH_PROP)));
-    Assertions.assertEquals(transactionsProcessed.get(0).txId(), Long.valueOf(summary.get(MAX_TX_ID__PROP)));
+    Assertions.assertEquals(99L, Long.valueOf(summary.get(TX_ID_VALID_THROUGH_PROP)));
+    Assertions.assertEquals(100L, Long.valueOf(summary.get(MAX_TX_ID_PROP)));
   }
 
   @Test
@@ -234,29 +248,32 @@ public class CoordinatorTest extends ChannelTestBase {
     OffsetDateTime ts = OffsetDateTime.ofInstant(Instant.now(), ZoneOffset.UTC);
     DeleteFile deleteFile = EventTestUtil.createDeleteFile();
 
-    UUID commitId =
-        coordinatorTest(
-            currentCommitId -> {
-              Event duplicateCommitResponse =
-                  new Event(
-                      config.controlGroupId(),
-                      new DataWritten(
-                          StructType.of(),
-                          currentCommitId,
-                          new TableReference("catalog", ImmutableList.of("db"), "tbl"),
-                          ImmutableList.of(),
-                          ImmutableList.of(deleteFile, deleteFile))); // duplicate delete files
+    // CHANGED: Use the new transaction object
+    TableReference tableRef = TableReference.of("catalog", TableIdentifier.of("db", "tbl"));
 
-              return ImmutableList.of(
-                  duplicateCommitResponse,
-                  duplicateCommitResponse, // duplicate commit response
-                  new Event(
-                      config.controlGroupId(),
-                          new TransactionDataComplete(
-                                  currentCommitId,
-                                  ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L, ts)),
-                                  ImmutableList.of(new TopicPartitionTransaction("topic", 1, 100L)))));
-            });
+    UUID commitId =
+            coordinatorTest(
+                    currentCommitId -> {
+                      Event duplicateCommitResponse =
+                              new Event(
+                                      config.controlGroupId(),
+                                      new DataWritten(
+                                              StructType.of(),
+                                              currentCommitId,
+                                              tableRef,
+                                              ImmutableList.of(),
+                                              ImmutableList.of(deleteFile, deleteFile))); // duplicate delete files
+
+                      return ImmutableList.of(
+                              duplicateCommitResponse,
+                              duplicateCommitResponse, // duplicate commit response
+                              new Event(
+                                      config.controlGroupId(),
+                                      new TransactionDataComplete(
+                                              currentCommitId,
+                                              ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L, ts)),
+                                              ImmutableList.of(new TableTopicPartitionTransaction("topic", 1, "catalog", TABLE_IDENTIFIER, 100L)))));
+                    });
 
     assertCommitTable(1, commitId, ts);
     assertCommitComplete(2, commitId, ts);
@@ -271,29 +288,32 @@ public class CoordinatorTest extends ChannelTestBase {
   }
 
   private void validateAddedFiles(
-      Snapshot snapshot, Set<String> expectedDataFilePaths, PartitionSpec expectedSpec) {
+          Snapshot snapshot, Set<String> expectedDataFilePaths, PartitionSpec expectedSpec) {
     final List<DataFile> addedDataFiles = ImmutableList.copyOf(snapshot.addedDataFiles(table.io()));
     final List<DeleteFile> addedDeleteFiles =
-        ImmutableList.copyOf(snapshot.addedDeleteFiles(table.io()));
+            ImmutableList.copyOf(snapshot.addedDeleteFiles(table.io()));
 
     Assertions.assertEquals(
-        expectedDataFilePaths,
-        addedDataFiles.stream().map(ContentFile::path).collect(Collectors.toSet()));
+            expectedDataFilePaths,
+            addedDataFiles.stream().map(ContentFile::path).collect(Collectors.toSet()));
 
     Assertions.assertEquals(
-        ImmutableSet.of(expectedSpec.specId()),
-        Stream.concat(addedDataFiles.stream(), addedDeleteFiles.stream())
-            .map(ContentFile::specId)
-            .collect(Collectors.toSet()));
+            ImmutableSet.of(expectedSpec.specId()),
+            Stream.concat(addedDataFiles.stream(), addedDeleteFiles.stream())
+                    .map(ContentFile::specId)
+                    .collect(Collectors.toSet()));
   }
 
   @Test
   public void testTxIdValidThroughInSnapshotSummary() {
     Assertions.assertEquals(0, ImmutableList.copyOf(table.snapshots().iterator()).size());
 
+    // CHANGED: This test now uses the richer object directly
+    TableReference tableRef = TableReference.of("catalog", TABLE_IDENTIFIER);
     Map<TopicPartition, Long> txIdPerPartition = ImmutableMap.of(
             new TopicPartition("topic", 1), 100L,
             new TopicPartition("topic", 2), 102L);
+
     OffsetDateTime ts = OffsetDateTime.ofInstant(Instant.now(), ZoneOffset.UTC);
     UUID commitId =
             coordinatorTxIdValidThroughTest(ImmutableList.of(EventTestUtil.createDataFile()), ImmutableList.of(), ts, txIdPerPartition);
@@ -319,21 +339,9 @@ public class CoordinatorTest extends ChannelTestBase {
     Assertions.assertEquals(
             Long.toString(ts.toInstant().toEpochMilli()), summary.get(VTTS_SNAPSHOT_PROP));
     Assertions.assertEquals(99L, Long.valueOf(summary.get(TX_ID_VALID_THROUGH_PROP)));
-    Assertions.assertEquals(102L, Long.valueOf(summary.get(MAX_TX_ID__PROP)));
+    Assertions.assertEquals(102L, Long.valueOf(summary.get(MAX_TX_ID_PROP)));
   }
 
-  /**
-   *
-   *
-   * <ul>
-   *   <li>Sets up an empty table with 2 partition specs
-   *   <li>Starts a coordinator with 2 worker assignment each handling a different topic-partition
-   *   <li>Sends a commit request to workers
-   *   <li>Each worker writes datafiles with a different partition spec
-   *   <li>The coordinator receives datafiles from both workers eventually and commits them to the
-   *       table
-   * </ul>
-   */
   @Test
   public void testCommitMultiPartitionSpecAppendDataFiles() {
     final PartitionSpec spec1 = table.spec();
@@ -349,95 +357,92 @@ public class CoordinatorTest extends ChannelTestBase {
     final List<MemberDescription> members = Lists.newArrayList();
     for (int i : ImmutableList.of(0, 1)) {
       members.add(
-          new MemberDescription(
-              "memberId" + i,
-              "clientId" + i,
-              "host" + i,
-              new MemberAssignment(ImmutableSet.of(new TopicPartition(SRC_TOPIC_NAME, i)))));
+              new MemberDescription(
+                      "memberId" + i,
+                      "clientId" + i,
+                      "host" + i,
+                      new MemberAssignment(ImmutableSet.of(new TopicPartition(SRC_TOPIC_NAME, i)))));
     }
 
     final Coordinator coordinator = new Coordinator(catalog, config, members, clientFactory);
     initConsumer();
 
-    // start a new commit immediately and wait for all workers to respond infinitely
     when(config.commitIntervalMs()).thenReturn(0);
     when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
     coordinator.process();
 
-    // retrieve commitId from commit request produced by coordinator
     final byte[] bytes = producer.history().get(0).value();
     final Event commitRequest = AvroUtil.decode(bytes);
     assert commitRequest.type().equals(PayloadType.START_COMMIT);
     final UUID commitId = ((StartCommit) commitRequest.payload()).commitId();
 
-    // each worker sends its responses for the commit request
     Map<Integer, PartitionSpec> workerIdToSpecMap =
-        ImmutableMap.of(
-            1, spec1, // worker 1 produces datafiles with the old partition spec
-            2, spec2 // worker 2 produces datafiles with the new partition spec
+            ImmutableMap.of(
+                    1, spec1,
+                    2, spec2
             );
 
+    // CHANGED: Use the new transaction object
+    TableReference tableRef = TableReference.of("catalog", TABLE_IDENTIFIER);
     int currentControlTopicOffset = 1;
     for (Map.Entry<Integer, PartitionSpec> entry : workerIdToSpecMap.entrySet()) {
       Integer workerId = entry.getKey();
       PartitionSpec spec = entry.getValue();
 
       final DataFile dataFile =
-          DataFiles.builder(spec)
-              .withPath(String.format("file%d.parquet", workerId))
-              .withFileSizeInBytes(100)
-              .withRecordCount(5)
-              .build();
+              DataFiles.builder(spec)
+                      .withPath(String.format("file%d.parquet", workerId))
+                      .withFileSizeInBytes(100)
+                      .withRecordCount(5)
+                      .build();
 
       consumer.addRecord(
-          new ConsumerRecord<>(
-              CTL_TOPIC_NAME,
-              0,
-              currentControlTopicOffset,
-              "key",
-              AvroUtil.encode(
-                  new Event(
-                      config.controlGroupId(),
-                      new DataWritten(
-                          spec.partitionType(),
-                          commitId,
-                          TableReference.of("catalog", TABLE_IDENTIFIER),
-                          ImmutableList.of(dataFile),
-                          ImmutableList.of())))));
+              new ConsumerRecord<>(
+                      CTL_TOPIC_NAME,
+                      0,
+                      currentControlTopicOffset,
+                      "key",
+                      AvroUtil.encode(
+                              new Event(
+                                      config.controlGroupId(),
+                                      new DataWritten(
+                                              spec.partitionType(),
+                                              commitId,
+                                              tableRef,
+                                              ImmutableList.of(dataFile),
+                                              ImmutableList.of())))));
       currentControlTopicOffset += 1;
 
       consumer.addRecord(
-          new ConsumerRecord<>(
-              CTL_TOPIC_NAME,
-              0,
-              currentControlTopicOffset,
-              "key",
-              AvroUtil.encode(
-                  new Event(
-                      config.controlGroupId(),
-                      new TransactionDataComplete(
-                          commitId,
-                          ImmutableList.of(
-                              new TopicPartitionOffset(
-                                  SRC_TOPIC_NAME,
-                                  0,
-                                  100L,
-                                  OffsetDateTime.ofInstant(
-                                      Instant.ofEpochMilli(100L), ZoneOffset.UTC))),
-                              ImmutableList.of(
-                                  new TopicPartitionTransaction(SRC_TOPIC_NAME, 0, 100L),
-                                  new TopicPartitionTransaction(SRC_TOPIC_NAME, 1, 110L),
-                                      new TopicPartitionTransaction(SRC_TOPIC_NAME, 2, 102L)))))));
+              new ConsumerRecord<>(
+                      CTL_TOPIC_NAME,
+                      0,
+                      currentControlTopicOffset,
+                      "key",
+                      AvroUtil.encode(
+                              new Event(
+                                      config.controlGroupId(),
+                                      new TransactionDataComplete(
+                                              commitId,
+                                              ImmutableList.of(
+                                                      new TopicPartitionOffset(
+                                                              SRC_TOPIC_NAME,
+                                                              0,
+                                                              100L,
+                                                              OffsetDateTime.ofInstant(
+                                                                      Instant.ofEpochMilli(100L), ZoneOffset.UTC))),
+                                              ImmutableList.of(
+                                                      new TableTopicPartitionTransaction(SRC_TOPIC_NAME, 0, "catalog", TABLE_IDENTIFIER, 100L),
+                                                      new TableTopicPartitionTransaction(SRC_TOPIC_NAME, 1, "catalog", TABLE_IDENTIFIER, 110L),
+                                                      new TableTopicPartitionTransaction(SRC_TOPIC_NAME, 2, "catalog", TABLE_IDENTIFIER, 102L)))))));
       currentControlTopicOffset += 1;
     }
 
-    // all workers have responded so coordinator can process responses now
     coordinator.process();
 
-    // assertions
     table.refresh();
     final List<Snapshot> snapshots = ImmutableList.copyOf(table.snapshots());
-    Assertions.assertEquals(2, snapshots.size(), "Expected 2 snapshots, one for each spec.");
+    Assertions.assertEquals(2, snapshots.size());
 
     final Snapshot firstSnapshot = snapshots.get(0);
     final Snapshot secondSnapshot = snapshots.get(1);
@@ -445,36 +450,15 @@ public class CoordinatorTest extends ChannelTestBase {
     validateAddedFiles(firstSnapshot, ImmutableSet.of("file1.parquet"), spec1);
     validateAddedFiles(secondSnapshot, ImmutableSet.of("file2.parquet"), spec2);
 
-    Assertions.assertEquals(
-        commitId.toString(),
-        firstSnapshot.summary().get(COMMIT_ID_SNAPSHOT_PROP),
-        "All snapshots should be tagged with a commit-id");
-    Assertions.assertNull(
-        firstSnapshot.summary().getOrDefault(OFFSETS_SNAPSHOT_PROP, null),
-        "Earlier snapshots should not include control-topic-offsets in their summary");
-    Assertions.assertNull(
-        firstSnapshot.summary().getOrDefault(VTTS_SNAPSHOT_PROP, null),
-        "Earlier snapshots should not include vtts in their summary");
+    Assertions.assertEquals(commitId.toString(), firstSnapshot.summary().get(COMMIT_ID_SNAPSHOT_PROP));
+    Assertions.assertNull(firstSnapshot.summary().getOrDefault(OFFSETS_SNAPSHOT_PROP, null));
+    Assertions.assertNull(firstSnapshot.summary().getOrDefault(VTTS_SNAPSHOT_PROP, null));
 
-    Assertions.assertEquals(
-        commitId.toString(),
-        secondSnapshot.summary().get(COMMIT_ID_SNAPSHOT_PROP),
-        "All snapshots should be tagged with a commit-id");
-    Assertions.assertEquals(
-        "{\"0\":5}",
-        secondSnapshot.summary().get(OFFSETS_SNAPSHOT_PROP),
-        "Only the most recent snapshot should include control-topic-offsets in it's summary");
-    Assertions.assertEquals(
-        "100",
-        secondSnapshot.summary().get(VTTS_SNAPSHOT_PROP),
-        "Only the most recent snapshot should include vtts in it's summary");
-    Assertions.assertEquals(
-            99L,
-            Long.valueOf(secondSnapshot.summary().get(TX_ID_VALID_THROUGH_PROP)),
-            "The lowest txId processed by all workers -1 should be the txId valid through");
-    Assertions.assertEquals(110L,
-            Long.valueOf(secondSnapshot.summary().get(MAX_TX_ID__PROP)),
-            "Max txId processed by all workers should be the max txId");
+    Assertions.assertEquals(commitId.toString(), secondSnapshot.summary().get(COMMIT_ID_SNAPSHOT_PROP));
+    Assertions.assertEquals("{\"0\":5}", secondSnapshot.summary().get(OFFSETS_SNAPSHOT_PROP));
+    Assertions.assertEquals("100", secondSnapshot.summary().get(VTTS_SNAPSHOT_PROP));
+    Assertions.assertEquals(99L, Long.valueOf(secondSnapshot.summary().get(TX_ID_VALID_THROUGH_PROP)));
+    Assertions.assertEquals(110L, Long.valueOf(secondSnapshot.summary().get(MAX_TX_ID_PROP)));
   }
 
   private void assertCommitTable(int idx, UUID commitId, OffsetDateTime ts) {
@@ -484,7 +468,7 @@ public class CoordinatorTest extends ChannelTestBase {
     CommitToTable commitTablePayload = (CommitToTable) commitTable.payload();
     assertThat(commitTablePayload.commitId()).isEqualTo(commitId);
     assertThat(commitTablePayload.tableReference().identifier().toString())
-        .isEqualTo(TABLE_IDENTIFIER.toString());
+            .isEqualTo(TABLE_IDENTIFIER.toString());
     assertThat(commitTablePayload.validThroughTs()).isEqualTo(ts);
   }
 
@@ -497,32 +481,34 @@ public class CoordinatorTest extends ChannelTestBase {
     assertThat(commitCompletePayload.validThroughTs()).isEqualTo(ts);
   }
 
+  // CHANGED: Helper method signature and implementation
   private UUID coordinatorTest(
-      List<DataFile> dataFiles, List<DeleteFile> deleteFiles, OffsetDateTime ts, List<TopicPartitionTransaction> transactionsProcessed) {
+          List<DataFile> dataFiles, List<DeleteFile> deleteFiles, OffsetDateTime ts, List<TableTopicPartitionTransaction> transactionsProcessed) {
     return coordinatorTest(
-        currentCommitId -> {
-          Event commitResponse =
-              new Event(
-                  config.controlGroupId(),
-                  new DataWritten(
-                      StructType.of(),
-                      currentCommitId,
-                      new TableReference("catalog", ImmutableList.of("db"), "tbl"),
-                      dataFiles,
-                      deleteFiles));
+            currentCommitId -> {
+              Event commitResponse =
+                      new Event(
+                              config.controlGroupId(),
+                              new DataWritten(
+                                      StructType.of(),
+                                      currentCommitId,
+                                      TableReference.of("catalog", TableIdentifier.of("db", "tbl")),
+                                      dataFiles,
+                                      deleteFiles));
 
-          Event commitReady =
-              new Event(
-                  config.controlGroupId(),
-                  new TransactionDataComplete(
-                      currentCommitId,
-                      ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L, ts)),
-                         transactionsProcessed));
+              Event commitReady =
+                      new Event(
+                              config.controlGroupId(),
+                              new TransactionDataComplete(
+                                      currentCommitId,
+                                      ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L, ts)),
+                                      transactionsProcessed));
 
-          return ImmutableList.of(commitResponse, commitReady);
-        });
+              return ImmutableList.of(commitResponse, commitReady);
+            });
   }
 
+  // CHANGED: Helper method implementation
   private UUID coordinatorTxIdValidThroughTest(
           List<DataFile> dataFiles, List<DeleteFile> deleteFiles, OffsetDateTime ts, Map<TopicPartition, Long> txIdPerPartition) {
     return coordinatorTest(
@@ -533,9 +519,14 @@ public class CoordinatorTest extends ChannelTestBase {
                               new DataWritten(
                                       StructType.of(),
                                       currentCommitId,
-                                      new TableReference("catalog", ImmutableList.of("db"), "tbl"),
+                                      TableReference.of("catalog", TableIdentifier.of("db", "tbl")),
                                       dataFiles,
                                       deleteFiles));
+
+              TableReference tableRef = TableReference.of("catalog", TableIdentifier.of("db", "tbl"));
+              List<TableTopicPartitionTransaction> tableTxIds = txIdPerPartition.entrySet().stream()
+                      .map(entry -> new TableTopicPartitionTransaction(entry.getKey().topic(), entry.getKey().partition(), "catalog", TABLE_IDENTIFIER, entry.getValue()))
+                      .collect(Collectors.toList());
 
               Event commitReady =
                       new Event(
@@ -543,9 +534,7 @@ public class CoordinatorTest extends ChannelTestBase {
                               new TransactionDataComplete(
                                       currentCommitId,
                                       ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L, ts)),
-                                      txIdPerPartition.entrySet().stream()
-                                              .map(entry -> new TopicPartitionTransaction(entry.getKey().topic(), entry.getKey().partition(), entry.getValue()))
-                                              .collect(Collectors.toList())));
+                                      tableTxIds));
 
               return ImmutableList.of(commitResponse, commitReady);
             });
@@ -557,9 +546,7 @@ public class CoordinatorTest extends ChannelTestBase {
 
     Coordinator coordinator = new Coordinator(catalog, config, ImmutableList.of(), clientFactory);
 
-    // init consumer after subscribe()
     initConsumer();
-
     coordinator.process();
 
     assertThat(producer.transactionCommitted()).isTrue();
@@ -579,7 +566,6 @@ public class CoordinatorTest extends ChannelTestBase {
     }
 
     when(config.commitIntervalMs()).thenReturn(0);
-
     coordinator.process();
 
     return commitId;

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/EventDecoderTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/EventDecoderTest.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -37,7 +37,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
-
 import io.tabular.iceberg.connect.events.TopicPartitionTxId;
 import io.tabular.iceberg.connect.events.TransactionDataComplete;
 import org.apache.avro.Schema;
@@ -64,10 +63,10 @@ public class EventDecoderTest {
   @Test
   public void testCommitRequestBecomesStartCommit() {
     io.tabular.iceberg.connect.events.Event event =
-        new io.tabular.iceberg.connect.events.Event(
-            "cg-connector",
-            io.tabular.iceberg.connect.events.EventType.COMMIT_REQUEST,
-            new CommitRequestPayload(commitId));
+            new io.tabular.iceberg.connect.events.Event(
+                    "cg-connector",
+                    io.tabular.iceberg.connect.events.EventType.COMMIT_REQUEST,
+                    new CommitRequestPayload(commitId));
 
     byte[] data = io.tabular.iceberg.connect.events.Event.encode(event);
 
@@ -83,15 +82,15 @@ public class EventDecoderTest {
   @Test
   public void testCommitResponseBecomesDataWrittenUnpartitioned() {
     io.tabular.iceberg.connect.events.Event event =
-        new io.tabular.iceberg.connect.events.Event(
-            "cg-connector",
-            EventType.COMMIT_RESPONSE,
-            new CommitResponsePayload(
-                Types.StructType.of(),
-                commitId,
-                new TableName(Collections.singletonList("db"), "tbl"),
-                Arrays.asList(EventTestUtil.createDataFile(), EventTestUtil.createDataFile()),
-                Arrays.asList(EventTestUtil.createDeleteFile(), EventTestUtil.createDeleteFile())));
+            new io.tabular.iceberg.connect.events.Event(
+                    "cg-connector",
+                    EventType.COMMIT_RESPONSE,
+                    new CommitResponsePayload(
+                            Types.StructType.of(),
+                            commitId,
+                            new TableName(Collections.singletonList("db"), "tbl"),
+                            Arrays.asList(EventTestUtil.createDataFile(), EventTestUtil.createDataFile()),
+                            Arrays.asList(EventTestUtil.createDeleteFile(), EventTestUtil.createDeleteFile())));
 
     byte[] data = io.tabular.iceberg.connect.events.Event.encode(event);
 
@@ -108,12 +107,12 @@ public class EventDecoderTest {
     assertThat(payload.tableReference().identifier()).isEqualTo(TableIdentifier.of("db", "tbl"));
     // should have an empty partition spec on the schema
     Schema.Field field =
-        payload.getSchema().getFields().get(2).schema().getTypes().stream()
-            .filter(s -> s.getType() != Schema.Type.NULL)
-            .findFirst()
-            .get()
-            .getElementType()
-            .getField("partition");
+            payload.getSchema().getFields().get(2).schema().getTypes().stream()
+                    .filter(s -> s.getType() != Schema.Type.NULL)
+                    .findFirst()
+                    .get()
+                    .getElementType()
+                    .getField("partition");
     assertThat(field.schema().getFields()).isEmpty();
   }
 
@@ -121,37 +120,37 @@ public class EventDecoderTest {
   public void testCommitResponseBecomesDataWrittenPartitioned() {
 
     org.apache.iceberg.Schema schemaSpec =
-        new org.apache.iceberg.Schema(
-            Types.NestedField.required(1, "i", Types.IntegerType.get()),
-            Types.NestedField.required(2, "s", Types.StringType.get()),
-            Types.NestedField.required(3, "ts1", Types.TimestampType.withZone()),
-            Types.NestedField.required(4, "ts2", Types.TimestampType.withZone()),
-            Types.NestedField.required(5, "ts3", Types.TimestampType.withZone()),
-            Types.NestedField.required(6, "ts4", Types.TimestampType.withZone()));
+            new org.apache.iceberg.Schema(
+                    Types.NestedField.required(1, "i", Types.IntegerType.get()),
+                    Types.NestedField.required(2, "s", Types.StringType.get()),
+                    Types.NestedField.required(3, "ts1", Types.TimestampType.withZone()),
+                    Types.NestedField.required(4, "ts2", Types.TimestampType.withZone()),
+                    Types.NestedField.required(5, "ts3", Types.TimestampType.withZone()),
+                    Types.NestedField.required(6, "ts4", Types.TimestampType.withZone()));
 
     List<String> partitionFields =
-        ImmutableList.of(
-            "year(ts1)",
-            "month(ts2)",
-            "day(ts3)",
-            "hour(ts4)",
-            "bucket(i, 4)",
-            "truncate(s, 10)",
-            "s");
+            ImmutableList.of(
+                    "year(ts1)",
+                    "month(ts2)",
+                    "day(ts3)",
+                    "hour(ts4)",
+                    "bucket(i, 4)",
+                    "truncate(s, 10)",
+                    "s");
     PartitionSpec spec = SchemaUtils.createPartitionSpec(schemaSpec, partitionFields);
 
     Types.StructType structType = spec.partitionType();
 
     io.tabular.iceberg.connect.events.Event event =
-        new io.tabular.iceberg.connect.events.Event(
-            "cg-connector",
-            EventType.COMMIT_RESPONSE,
-            new CommitResponsePayload(
-                structType,
-                commitId,
-                new TableName(Collections.singletonList("db"), "tbl"),
-                Arrays.asList(EventTestUtil.createDataFile(), EventTestUtil.createDataFile()),
-                Arrays.asList(EventTestUtil.createDeleteFile(), EventTestUtil.createDeleteFile())));
+            new io.tabular.iceberg.connect.events.Event(
+                    "cg-connector",
+                    EventType.COMMIT_RESPONSE,
+                    new CommitResponsePayload(
+                            structType,
+                            commitId,
+                            new TableName(Collections.singletonList("db"), "tbl"),
+                            Arrays.asList(EventTestUtil.createDataFile(), EventTestUtil.createDataFile()),
+                            Arrays.asList(EventTestUtil.createDeleteFile(), EventTestUtil.createDeleteFile())));
 
     byte[] data = io.tabular.iceberg.connect.events.Event.encode(event);
 
@@ -167,36 +166,36 @@ public class EventDecoderTest {
     assertThat(payload.tableReference().catalog()).isEqualTo("catalog");
     assertThat(payload.tableReference().identifier()).isEqualTo(TableIdentifier.of("db", "tbl"));
 
-    assertThat(payload.writeSchema()).isEqualTo(
-            Types.StructType.of(
-                    Types.NestedField.required(10_300, "commit_id", Types.UUIDType.get()),
-                    Types.NestedField.required(
-                            10_301, "table_reference", TableReference.ICEBERG_SCHEMA),
-                    Types.NestedField.optional(
-                            10_302,
-                            "data_files",
-                            Types.ListType.ofRequired(10_303, DataFile.getType(spec.partitionType()))),
-                    Types.NestedField.optional(
-                            10_304,
-                            "delete_files",
-                            Types.ListType.ofRequired(10_305, DataFile.getType(spec.partitionType())))));
+    assertThat(payload.writeSchema())
+            .isEqualTo(
+                    Types.StructType.of(
+                            Types.NestedField.required(10_300, "commit_id", Types.UUIDType.get()),
+                            Types.NestedField.required(
+                                    10_301, "table_reference", TableReference.ICEBERG_SCHEMA),
+                            Types.NestedField.optional(
+                                    10_302,
+                                    "data_files",
+                                    Types.ListType.ofRequired(10_303, DataFile.getType(spec.partitionType()))),
+                            Types.NestedField.optional(
+                                    10_304,
+                                    "delete_files",
+                                    Types.ListType.ofRequired(10_305, DataFile.getType(spec.partitionType())))));
   }
 
   @Test
   public void testCommitReadyBecomesDataComplete() {
     io.tabular.iceberg.connect.events.Event event =
-        new io.tabular.iceberg.connect.events.Event(
-            "cg-connector",
-            EventType.COMMIT_READY,
-            new CommitReadyPayload(
-                commitId,
-                Arrays.asList(
-                    new TopicPartitionOffset("topic", 1, 1L, 1L),
-                    new TopicPartitionOffset("topic", 2, null, null)),
-                Arrays.asList(
-                        new TopicPartitionTxId("topic", 1, 1L),
-                        new TopicPartitionTxId("topic", 2, null))));
-
+            new io.tabular.iceberg.connect.events.Event(
+                    "cg-connector",
+                    EventType.COMMIT_READY,
+                    new CommitReadyPayload(
+                            commitId,
+                            Arrays.asList(
+                                    new TopicPartitionOffset("topic", 1, 1L, 1L),
+                                    new TopicPartitionOffset("topic", 2, null, null)),
+                            Arrays.asList(
+                                    new TopicPartitionTxId("topic", 1, 1L),
+                                    new TopicPartitionTxId("topic", 2, null))));
 
     byte[] data = io.tabular.iceberg.connect.events.Event.encode(event);
 
@@ -212,30 +211,27 @@ public class EventDecoderTest {
     assertThat(payload.assignments().get(0).partition()).isEqualTo(1);
     assertThat(payload.assignments().get(0).offset()).isEqualTo(1L);
     assertThat(payload.assignments().get(0).timestamp())
-        .isEqualTo(OffsetDateTime.ofInstant(Instant.ofEpochMilli(1), ZoneOffset.UTC));
+            .isEqualTo(OffsetDateTime.ofInstant(Instant.ofEpochMilli(1), ZoneOffset.UTC));
 
     assertThat(payload.assignments().get(1).topic()).isEqualTo("topic");
     assertThat(payload.assignments().get(1).partition()).isEqualTo(2);
     assertThat(payload.assignments().get(1).offset()).isNull();
     assertThat(payload.assignments().get(1).timestamp()).isNull();
 
-    assertThat(payload.txIds().get(0).topic()).isEqualTo("topic");
-    assertThat(payload.txIds().get(0).partition()).isEqualTo(1);
-    assertThat(payload.txIds().get(0).txId()).isEqualTo(1L);
-
-    assertThat(payload.txIds().get(1).topic()).isEqualTo("topic");
-    assertThat(payload.txIds().get(1).partition()).isEqualTo(2);
-    assertThat(payload.txIds().get(1).txId()).isNull();
+    // TableTopicPartitionTransaction objects.
+    // This information is dropped, so we expect an empty list.
+    assertThat(payload.tableTxIds()).isNotNull();
+    assertThat(payload.tableTxIds()).isEmpty();
   }
 
   @Test
   public void testCommitTableBecomesCommitToTable() {
     io.tabular.iceberg.connect.events.Event event =
-        new io.tabular.iceberg.connect.events.Event(
-            "cg-connector",
-            EventType.COMMIT_TABLE,
-            new CommitTablePayload(
-                commitId, new TableName(Collections.singletonList("db"), "tbl"), 1L, 2L));
+            new io.tabular.iceberg.connect.events.Event(
+                    "cg-connector",
+                    EventType.COMMIT_TABLE,
+                    new CommitTablePayload(
+                            commitId, new TableName(Collections.singletonList("db"), "tbl"), 1L, 2L));
 
     byte[] data = io.tabular.iceberg.connect.events.Event.encode(event);
 
@@ -248,7 +244,7 @@ public class EventDecoderTest {
     assertThat(payload.commitId()).isEqualTo(commitId);
     assertThat(payload.snapshotId()).isEqualTo(1L);
     assertThat(payload.validThroughTs())
-        .isEqualTo(OffsetDateTime.ofInstant(Instant.ofEpochMilli(2L), ZoneOffset.UTC));
+            .isEqualTo(OffsetDateTime.ofInstant(Instant.ofEpochMilli(2L), ZoneOffset.UTC));
     assertThat(payload.tableReference().catalog()).isEqualTo(catalogName);
     assertThat(payload.tableReference().identifier()).isEqualTo(TableIdentifier.of("db", "tbl"));
   }
@@ -280,8 +276,8 @@ public class EventDecoderTest {
   @Test
   public void testCommitCompleteBecomesCommitCompleteSerialization() {
     io.tabular.iceberg.connect.events.Event event =
-        new io.tabular.iceberg.connect.events.Event(
-            "cg-connector", EventType.COMMIT_COMPLETE, new CommitCompletePayload(commitId, 2L));
+            new io.tabular.iceberg.connect.events.Event(
+                    "cg-connector", EventType.COMMIT_COMPLETE, new CommitCompletePayload(commitId, 2L));
 
     byte[] data = io.tabular.iceberg.connect.events.Event.encode(event);
 
@@ -291,7 +287,7 @@ public class EventDecoderTest {
     CommitComplete payload = (CommitComplete) result.payload();
     assertThat(payload.commitId()).isEqualTo(commitId);
     assertThat(payload.validThroughTs())
-        .isEqualTo(OffsetDateTime.ofInstant(Instant.ofEpochMilli(2L), ZoneOffset.UTC));
+            .isEqualTo(OffsetDateTime.ofInstant(Instant.ofEpochMilli(2L), ZoneOffset.UTC));
   }
 
   @Test

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/WorkerTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/WorkerTest.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -29,6 +29,8 @@ import io.tabular.iceberg.connect.data.IcebergWriter;
 import io.tabular.iceberg.connect.data.IcebergWriterFactory;
 import io.tabular.iceberg.connect.data.WriterResult;
 import io.tabular.iceberg.connect.events.EventTestUtil;
+import io.tabular.iceberg.connect.events.TableTopicPartitionTransaction;
+import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -70,12 +72,8 @@ public class WorkerTest {
     when(config.catalogName()).thenReturn("catalog");
     Map<String, Object> value = ImmutableMap.of(TRANSACTION_FIELD_NAME, 743);
     Committable committable = workerTest(config, value);
-
-    assertThat(
-            committable
-                    .txIdsByTopicPartition()
-                    .get(committable.txIdsByTopicPartition().keySet().iterator().next()))
-            .isEqualTo(743L);
+    List<TableTopicPartitionTransaction> tableTxIds = committable.getTableTxIds();
+    assertThat(tableTxIds.get(0).txId()).isEqualTo(743L);
   }
 
   private Committable workerTest(IcebergSinkConfig config, Map<String, Object> value) {
@@ -91,12 +89,14 @@ public class WorkerTest {
     IcebergWriterFactory writerFactory = mock(IcebergWriterFactory.class);
     when(writerFactory.createWriter(any(), any(), anyBoolean())).thenReturn(writer);
 
-    Writer worker = new Worker(config, writerFactory);
+    Worker worker = new Worker(config, writerFactory);
 
     // save a record
     SinkRecord rec = new SinkRecord(SRC_TOPIC_NAME, 0, null, "key", null, value, 0L);
     worker.write(ImmutableList.of(rec));
 
+    // Now calling beginCommit() before committable() to initialize internal state for this change to work
+    worker.beginCommit();
     Committable committable = worker.committable();
 
     assertThat(committable.offsetsByTopicPartition()).hasSize(1);


### PR DESCRIPTION
This commit refactors the commit process to prevent a race condition where transaction IDs from records arriving during a data flush could incorrectly affect that commit's transaction boundary that we calculate (txid-valid-through and txid-max).

The transaction ID state is now captured at the beginning of the `START_COMMIT` cycle via a new `worker.beginCommit()` method. This ensures a consistent and accurate view of the transaction's scope.

- The Worker and Coordinator now use per-table maps for more precise txid tracking.
- Coordinator state is now scoped per commitId and cleared reliably after each cycle, ensuring no state leaks between commits.