### PR TITLE
Refactor: Fix txid metadata calculations

### DIFF
--- a/kafka-connect-events/src/main/java/io/tabular/iceberg/connect/events/TableTopicPartitionTransaction.java
+++ b/kafka-connect-events/src/main/java/io/tabular/iceberg/connect/events/TableTopicPartitionTransaction.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.tabular.iceberg.connect.events;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.avro.Schema;
+import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
+
+public class TableTopicPartitionTransaction implements org.apache.avro.generic.IndexedRecord {
+
+    private String topic;
+    private Integer partition;
+    private String catalogName;
+    private List<String> namespace;
+    private String tableName;
+    private Long txId;
+
+    private final Schema avroSchema;
+
+    static final int TOPIC = 10_800;
+    static final int PARTITION = 10_801;
+    static final int TX_ID = 10_802;
+    static final int CATALOG_NAME = 10_803;
+    static final int NAMESPACE = 10_804;
+    static final int TABLE_NAME = 10_805;
+    static final int NAMESPACE_ELEMENT = 10_806;
+
+    public static final Types.StructType ICEBERG_SCHEMA =
+            Types.StructType.of(
+                    Types.NestedField.required(TOPIC, "topic", Types.StringType.get()),
+                    Types.NestedField.required(PARTITION, "partition", Types.IntegerType.get()),
+                    Types.NestedField.optional(TX_ID, "txId", Types.LongType.get()),
+                    Types.NestedField.required(CATALOG_NAME, "catalog_name", Types.StringType.get()),
+                    Types.NestedField.required(NAMESPACE, "namespace", Types.ListType.ofRequired(NAMESPACE_ELEMENT, Types.StringType.get())),
+                    Types.NestedField.required(TABLE_NAME, "table_name", Types.StringType.get())
+            );
+
+    private static final Schema AVRO_SCHEMA = AvroSchemaUtil.convert(ICEBERG_SCHEMA, TableTopicPartitionTransaction.class.getName());
+
+    public TableTopicPartitionTransaction(Schema avroSchema) {
+        this.avroSchema = avroSchema;
+    }
+
+    public TableTopicPartitionTransaction(String topic, int partition, String catalogName, TableIdentifier tableIdentifier, Long txId) {
+        this.topic = topic;
+        this.partition = partition;
+        this.catalogName = catalogName;
+        this.namespace = Lists.newArrayList(tableIdentifier.namespace().levels());
+        this.tableName = tableIdentifier.name();
+        this.txId = txId;
+        this.avroSchema = AVRO_SCHEMA;
+    }
+
+    public String topic() { return topic; }
+    public Integer partition() { return partition; }
+    public String catalogName() { return catalogName; }
+    public Long txId() { return txId; }
+
+    public TableIdentifier tableIdentifier() {
+        List<String> parts = Lists.newArrayList(namespace);
+        parts.add(tableName);
+        return TableIdentifier.of(parts.toArray(new String[0]));
+    }
+
+    @Override
+    public Schema getSchema() {
+        return avroSchema;
+    }
+
+    @Override
+    public void put(int i, Object v) {
+        switch (positionToId(i, avroSchema)) {
+            case TOPIC:
+                this.topic = v == null ? null : v.toString();
+                return;
+            case PARTITION:
+                this.partition = (Integer) v;
+                return;
+            case TX_ID:
+                this.txId = (Long) v;
+                return;
+            case CATALOG_NAME:
+                this.catalogName = v == null ? null : v.toString();
+                return;
+            case NAMESPACE:
+                if (v instanceof List) {
+                    this.namespace = ((List<?>) v).stream()
+                            .map(Object::toString)
+                            .collect(Collectors.toList());
+                }
+                return;
+            case TABLE_NAME:
+                this.tableName = v == null ? null : v.toString();
+                return;
+            default:
+                throw new IllegalArgumentException("Unknown field index: " + i);
+        }
+    }
+
+    @Override
+    public Object get(int i) {
+        switch (positionToId(i, avroSchema)) {
+            case TOPIC: return topic;
+            case PARTITION: return partition;
+            case TX_ID: return txId;
+            case CATALOG_NAME: return catalogName;
+            case NAMESPACE: return namespace;
+            case TABLE_NAME: return tableName;
+            default:
+                throw new IllegalArgumentException("Unknown field index: " + i);
+        }
+    }
+
+    static int positionToId(int position, Schema avroSchema) {
+        List<Schema.Field> fields = avroSchema.getFields();
+        Preconditions.checkArgument(
+                position >= 0 && position < fields.size(), "Invalid field position: " + position);
+        Object val = fields.get(position).getObjectProp(AvroSchemaUtil.FIELD_ID_PROP);
+        return val == null ? -1 : (int) val;
+    }
+}

--- a/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/IntegrationTestBase.java
+++ b/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/IntegrationTestBase.java
@@ -134,6 +134,11 @@ public class IntegrationTestBase {
     producer.send(new ProducerRecord<>(topicName, Long.toString(event.id()), eventStr));
   }
 
+  protected void send(String topicName, int partition, TestEvent event, boolean useSchema) {
+    String eventStr = event.serialize(useSchema);
+    producer.send(new ProducerRecord<>(topicName, partition, Long.toString(event.id()), eventStr));
+  }
+
   protected void flush() {
     producer.flush();
   }

--- a/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/IntegrationTxIdTest.java
+++ b/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/IntegrationTxIdTest.java
@@ -127,7 +127,7 @@ public class IntegrationTxIdTest extends IntegrationTestBase {
     public void testIcebergSinkMixedTxIdPartitions() {
         createTopic(testTopic, TEST_TOPIC_PARTITIONS);
         catalog.createTable(tableIdentifier, TEST_SCHEMA);
-        startConnector(true, 1);
+        startConnector(true, 3);
 
         send(testTopic, 0, new TestEvent(1, "type1", new Date(), "p0d1", null, 100L), true);
         send(testTopic, 1, new TestEvent(2, "type1", new Date(), "p1d1", null, 101L), true);

--- a/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/IntegrationTxIdTest.java
+++ b/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/IntegrationTxIdTest.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.tabular.iceberg.connect;
+
+import static io.tabular.iceberg.connect.TestEvent.TEST_SCHEMA;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.Date;
+import java.util.Map;
+import java.util.UUID;
+
+
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SupportsNamespaces;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class IntegrationTxIdTest extends IntegrationTestBase {
+
+    private static final String TEST_DB = "test";
+    private static final String TEST_TABLE_PREFIX = "foobar_";
+    private static final int TEST_TOPIC_PARTITIONS = 3;
+
+    private String tableName;
+    private TableIdentifier tableIdentifier;
+
+    @BeforeEach
+    public void beforeEach() {
+        // Each test will have a unique topic and table name to ensure isolation
+        this.testTopic = "test-topic-" + UUID.randomUUID();
+        this.tableName = TEST_TABLE_PREFIX + UUID.randomUUID().toString().replace("-", "_");
+        this.tableIdentifier = TableIdentifier.of(TEST_DB, tableName);
+
+        // Namespace can be shared, so create it if it doesn't exist
+        if (!((SupportsNamespaces) catalog).namespaceExists(Namespace.of(TEST_DB))) {
+            ((SupportsNamespaces) catalog).createNamespace(Namespace.of(TEST_DB));
+        }
+    }
+
+    @AfterEach
+    public void afterEach() {
+        context.stopConnector(connectorName);
+        deleteTopic(testTopic);
+        catalog.dropTable(tableIdentifier);
+    }
+
+    private void startConnector(boolean useSchema, int tasksMax) {
+        KafkaConnectContainer.Config connectorConfig =
+                new KafkaConnectContainer.Config(connectorName)
+                        .config("topics", testTopic)
+                        .config("connector.class", IcebergSinkConnector.class.getName())
+                        .config("tasks.max", tasksMax)
+                        .config("consumer.override.auto.offset.reset", "earliest")
+                        .config("key.converter", "org.apache.kafka.connect.json.JsonConverter")
+                        .config("key.converter.schemas.enable", false)
+                        .config("value.converter", "org.apache.kafka.connect.json.JsonConverter")
+                        .config("value.converter.schemas.enable", useSchema)
+                        .config("iceberg.tables", tableIdentifier.toString())
+                        .config("iceberg.control.commit.interval-ms", 5000) // Longer commit interval
+                        .config("iceberg.control.commit.timeout-ms", Integer.MAX_VALUE)
+                        .config("iceberg.kafka.auto.offset.reset", "earliest");
+
+        context.connectorCatalogProperties().forEach(connectorConfig::config);
+        context.startConnector(connectorConfig);
+    }
+
+    private Snapshot awaitSnapshot() {
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(60))
+                .pollInterval(Duration.ofSeconds(2))
+                .untilAsserted(
+                        () -> {
+                            Table table = catalog.loadTable(tableIdentifier);
+                            assertThat(table.snapshots()).hasSizeGreaterThanOrEqualTo(1);
+                        });
+        return catalog.loadTable(tableIdentifier).currentSnapshot();
+    }
+
+    private void assertSnapshotTxIdProps(Snapshot snapshot, long expectedMax, long expectedValidThrough) {
+        assertThat(snapshot).isNotNull();
+        Map<String, String> summary = snapshot.summary();
+        assertThat(summary.get("txid-max")).isEqualTo(String.valueOf(expectedMax));
+        assertThat(summary.get("txid-valid-through"))
+                .isEqualTo(String.valueOf(expectedValidThrough));
+    }
+
+    @Test
+    public void testIcebergSinkTxIdTracking() {
+        createTopic(testTopic, 1);
+        catalog.createTable(tableIdentifier, TEST_SCHEMA);
+        startConnector(true, 1);
+
+        send(testTopic, 0, new TestEvent(1, "type1", new Date(), "p0d1", null, 100L), true);
+        send(testTopic, 0, new TestEvent(2, "type1", new Date(), "p0d2", null, 101L), true);
+        send(testTopic, 0, new TestEvent(3, "type1", new Date(), "p0d3", null, 102L), true);
+        flush();
+
+        Snapshot snapshot = awaitSnapshot();
+
+        // valid-through should equal the max txid.
+        assertSnapshotTxIdProps(snapshot, 102, 102);
+    }
+
+    @Test
+    public void testIcebergSinkMixedTxIdPartitions() {
+        createTopic(testTopic, TEST_TOPIC_PARTITIONS);
+        catalog.createTable(tableIdentifier, TEST_SCHEMA);
+        startConnector(true, 1);
+
+        send(testTopic, 0, new TestEvent(1, "type1", new Date(), "p0d1", null, 100L), true);
+        send(testTopic, 1, new TestEvent(2, "type1", new Date(), "p1d1", null, 101L), true);
+        send(testTopic, 2, new TestEvent(3, "type1", new Date(), "p2d1", null, 108L), true);
+        flush();
+
+        Snapshot snapshot = awaitSnapshot();
+        // The max txid is the highest across all partitions, and valid-through is one less than that.
+        assertSnapshotTxIdProps(snapshot, 108, 99);
+    }
+
+    @Test
+    public void testIcebergSinkTxIdWraparound() {
+        createTopic(testTopic, 3);
+        catalog.createTable(tableIdentifier, TEST_SCHEMA);
+        startConnector(true, 1);
+
+        long highTxId1 = 4_294_967_290L;
+        long lowTxIdAfterWrap = 5L;
+        long highTxId2 = 4_294_967_280L;
+
+        send(testTopic, 0, new TestEvent(1, "type1", new Date(), "p0d1", null, highTxId1), true);
+        send(testTopic, 1, new TestEvent(2, "type1", new Date(), "p1d2", null, lowTxIdAfterWrap), true);
+        send(testTopic, 2, new TestEvent(3, "type1", new Date(), "p2d1", null, highTxId2), true);
+        flush();
+
+        Snapshot snapshot = awaitSnapshot();
+
+        // This test confirms the current behavior. The Coordinator's `compareTxIds` correctly
+        // handles wraparound for a single partition, so the highest txid for partition 0 is `5L`.
+        // However, the `Utilities` methods for calculating final `max` and `valid-through` do not
+        // account for wraparound when comparing values from *different* partitions.
+        // Expected max = simple max(5L, 4294967280L) = 4294967280L
+        // Expected valid-through = simple min(5L, 4294967280L) - 1 = 4L
+        assertSnapshotTxIdProps(snapshot, highTxId1, 4L);
+    }
+}

--- a/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/TestContext.java
+++ b/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/TestContext.java
@@ -71,6 +71,9 @@ public class TestContext {
   private static final int MINIO_PORT = 9000;
   private static final int CATALOG_PORT = 8181;
 
+  private static final String DEBUG_SUSPEND_COMMAND =
+          "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005";
+
   private TestContext() {
     network = Network.newNetwork();
 

--- a/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/TestEvent.java
+++ b/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/TestEvent.java
@@ -62,7 +62,8 @@ public class TestEvent {
           .field("type", org.apache.kafka.connect.data.Schema.STRING_SCHEMA)
           .field("ts", Timestamp.SCHEMA)
           .field("payload", org.apache.kafka.connect.data.Schema.STRING_SCHEMA)
-          .field("op", org.apache.kafka.connect.data.Schema.OPTIONAL_STRING_SCHEMA);
+          .field("op", org.apache.kafka.connect.data.Schema.OPTIONAL_STRING_SCHEMA)
+          .field("txid", org.apache.kafka.connect.data.Schema.OPTIONAL_INT64_SCHEMA);
 
   public static final PartitionSpec TEST_SPEC =
       PartitionSpec.builderFor(TEST_SCHEMA).day("ts").build();
@@ -79,17 +80,27 @@ public class TestEvent {
   private final Date ts;
   private final String payload;
   private final String op;
+  private final Long txid;
 
   public TestEvent(long id, String type, Date ts, String payload) {
-    this(id, type, ts, payload, null);
+    this(id, type, ts, payload, null, null);
   }
 
   public TestEvent(long id, String type, Date ts, String payload, String op) {
+    this(id, type, ts, payload, op, null);
+  }
+
+  public TestEvent(long id, String type, Date ts, String payload, String op, Long txid) {
     this.id = id;
     this.type = type;
     this.ts = ts;
     this.payload = payload;
     this.op = op;
+    this.txid = txid;
+  }
+
+  public Long txid() {
+    return txid;
   }
 
   public long id() {
@@ -120,7 +131,8 @@ public class TestEvent {
               .put("type", type)
               .put("ts", ts)
               .put("payload", payload)
-              .put("op", op);
+              .put("op", op)
+              .put("txid", txid);
 
       String convertMethod =
           useSchema ? "convertToJsonWithEnvelope" : "convertToJsonWithoutEnvelope";

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Channel.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Channel.java
@@ -56,7 +56,6 @@ public abstract class Channel {
   private final Admin admin;
   private final Map<Integer, Long> controlTopicOffsets = Maps.newHashMap();
   private final String producerId;
-  private final Map<Integer, Long> highestTxIdPerPartition = Maps.newHashMap();
 
   private final EventDecoder eventDecoder;
 
@@ -146,10 +145,6 @@ public abstract class Channel {
   protected Map<Integer, Long> controlTopicOffsets() {
     return controlTopicOffsets;
   }
-
-  protected Map<Integer, Long> highestTxIdPerPartition() {
-        return highestTxIdPerPartition;
-    }
 
   protected void commitConsumerOffsets() {
     Map<TopicPartition, OffsetAndMetadata> offsetsToCommit = Maps.newHashMap();

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Committable.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Committable.java
@@ -20,27 +20,27 @@ package io.tabular.iceberg.connect.channel;
 
 import io.tabular.iceberg.connect.data.Offset;
 import io.tabular.iceberg.connect.data.WriterResult;
+import io.tabular.iceberg.connect.events.TableTopicPartitionTransaction;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.kafka.common.TopicPartition;
-import java.util.stream.Collectors;
 
 class Committable {
 
   private final ImmutableMap<TopicPartition, Offset> offsetsByTopicPartition;
-  private final ImmutableMap<TopicPartition, Long> txIdsByTopicPartition;
+
+  private final ImmutableList<TableTopicPartitionTransaction> tableTxIds;
+
   private final ImmutableList<WriterResult> writerResults;
 
   Committable(
-          Map<TopicPartition, Offset> offsetsByTopicPartition, Map<TopicPartition, Long> txIdsByTopicPartition, List<WriterResult> writerResults) {
+          Map<TopicPartition, Offset> offsetsByTopicPartition,
+          List<TableTopicPartitionTransaction> tableTxIds,
+          List<WriterResult> writerResults) {
     this.offsetsByTopicPartition = ImmutableMap.copyOf(offsetsByTopicPartition);
-    this.txIdsByTopicPartition = ImmutableMap.copyOf(
-            txIdsByTopicPartition.entrySet().stream()
-                    .filter(entry -> entry.getValue() != null)
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
-    );
+    this.tableTxIds = ImmutableList.copyOf(tableTxIds);
     this.writerResults = ImmutableList.copyOf(writerResults);
   }
 
@@ -48,9 +48,9 @@ class Committable {
     return offsetsByTopicPartition;
   }
 
-    public Map<TopicPartition, Long> txIdsByTopicPartition() {
-        return txIdsByTopicPartition;
-    }
+  public List<TableTopicPartitionTransaction> getTableTxIds() {
+    return tableTxIds;
+  }
 
   public List<WriterResult> writerResults() {
     return writerResults;

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/CommitterImpl.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/CommitterImpl.java
@@ -23,6 +23,8 @@ import static java.util.stream.Collectors.toMap;
 
 import io.tabular.iceberg.connect.IcebergSinkConfig;
 import io.tabular.iceberg.connect.data.Offset;
+import io.tabular.iceberg.connect.events.TableTopicPartitionTransaction;
+import io.tabular.iceberg.connect.events.TransactionDataComplete;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
@@ -30,9 +32,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
-
-import io.tabular.iceberg.connect.events.TopicPartitionTransaction;
-import io.tabular.iceberg.connect.events.TransactionDataComplete;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.connect.events.DataWritten;
 import org.apache.iceberg.connect.events.Event;
@@ -107,7 +106,7 @@ public class CommitterImpl extends Channel implements Committer, AutoCloseable {
             receive(
                 envelope,
                 // CommittableSupplier that always returns empty committables
-                () -> new Committable(ImmutableMap.of(), ImmutableMap.of(), ImmutableList.of())));
+                () -> new Committable(ImmutableMap.of(), ImmutableList.of(), ImmutableList.of())));
   }
 
   private Map<TopicPartition, Long> fetchStableConsumerOffsets(String groupId) {
@@ -178,14 +177,13 @@ public class CommitterImpl extends Channel implements Committer, AutoCloseable {
                 })
             .collect(toList());
 
-    List<TopicPartitionTransaction> txIds = committable.txIdsByTopicPartition().entrySet().stream()
-            .map(entry -> new TopicPartitionTransaction(entry.getKey().topic(), entry.getKey().partition(), entry.getValue()))
-            .collect(toList());
+    //  TableTopicPartitionTransactions now
+    List<TableTopicPartitionTransaction> tableTxIds = committable.getTableTxIds();
 
     Event commitReady =
         new Event(
             config.controlGroupId(),
-            new TransactionDataComplete(commitId, assignments, txIds));
+            new TransactionDataComplete(commitId, assignments, tableTxIds));
     events.add(commitReady);
 
     Map<TopicPartition, Offset> offsets = committable.offsetsByTopicPartition();

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Coordinator.java
@@ -24,19 +24,21 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.tabular.iceberg.connect.IcebergSinkConfig;
 import io.tabular.iceberg.connect.data.Utilities;
+import io.tabular.iceberg.connect.events.TableTopicPartitionTransaction;
+import io.tabular.iceberg.connect.events.TransactionDataComplete;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 
-import io.tabular.iceberg.connect.events.TopicPartitionTransaction;
-import io.tabular.iceberg.connect.events.TransactionDataComplete;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
@@ -55,9 +57,11 @@ import org.apache.iceberg.connect.events.TableReference;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.Tasks;
 import org.apache.iceberg.util.ThreadPools;
 import org.apache.kafka.clients.admin.MemberDescription;
+import org.apache.kafka.common.TopicPartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,6 +82,11 @@ public class Coordinator extends Channel implements AutoCloseable {
   private final String snapshotOffsetsProp;
   private final ExecutorService exec;
   private final CommitState commitState;
+    /**
+     * Map of commit ID to a map of table identifiers to a map of topic partitions and their highest transaction IDs.
+     * This is used to track the transaction IDs for each table in the current commit.
+     */
+  private final Map<UUID, Map<TableIdentifier, Map<TopicPartition, Long>>> commitTxIdsByTable;
 
   public Coordinator(
       Catalog catalog,
@@ -95,6 +104,7 @@ public class Coordinator extends Channel implements AutoCloseable {
         String.format(OFFSETS_SNAPSHOT_PROP_FMT, config.controlTopic(), config.controlGroupId());
     this.exec = ThreadPools.newWorkerPool("iceberg-committer", config.commitThreads());
     this.commitState = new CommitState(config);
+    this.commitTxIdsByTable = Maps.newConcurrentMap();
 
     // initial poll with longer duration so the consumer will initialize...
     consumeAvailable(Duration.ofMillis(1000), this::receive);
@@ -125,18 +135,34 @@ public class Coordinator extends Channel implements AutoCloseable {
         commitState.addResponse(envelope);
         return true;
       case DATA_COMPLETE:
-        commitState.addReady(envelope);
-        if (envelope.event().payload() instanceof TransactionDataComplete) {
-          TransactionDataComplete payload = (TransactionDataComplete) envelope.event().payload();
-          List<TopicPartitionTransaction> txIds = payload.txIds();
-          LOG.debug("Received transaction data complete event with {} txIds", txIds.size());
-          txIds.forEach(
-                  txId -> highestTxIdPerPartition().put(txId.partition(),
-                          compareTxIds(highestTxIdPerPartition().getOrDefault(txId.partition(), 0L), txId.txId())));
-        }
-        if (commitState.isCommitReady(totalPartitionCount)) {
-          commit(false);
-        }
+          commitState.addReady(envelope);
+          if (envelope.event().payload() instanceof TransactionDataComplete) {
+            TransactionDataComplete payload = (TransactionDataComplete) envelope.event().payload();
+            List<TableTopicPartitionTransaction> tableTxIds = payload.tableTxIds();
+            UUID commitId = payload.commitId();
+
+            LOG.info("TRACE: Received transaction data complete event with {} txIds for commitId {} and here it is {}",
+                    tableTxIds.size(), commitId, tableTxIds);
+
+            // Only process if this commitId is not already present
+            if (!commitTxIdsByTable.containsKey(commitId)) {
+              Map<TableIdentifier, Map<TopicPartition, Long>> currentCommitTxIds =
+                      commitTxIdsByTable.computeIfAbsent(commitId, k -> Maps.newConcurrentMap());
+
+              tableTxIds.forEach(txId -> {
+                TableIdentifier tableIdentifier = txId.tableIdentifier();
+                TopicPartition tp = new TopicPartition(txId.topic(), txId.partition());
+                Map<TopicPartition, Long> tableTxMap = currentCommitTxIds.computeIfAbsent(
+                        tableIdentifier, k -> Maps.newConcurrentMap());
+                tableTxMap.merge(tp, txId.txId(), this::compareTxIds);
+              });
+            } else {
+              LOG.info("TRACE: Commit ID {} already processed, ignoring duplicate TransactionDataComplete.", commitId);
+            }
+          }
+          if (commitState.isCommitReady(totalPartitionCount)) {
+            commit(false);
+          }
         return true;
     }
     return false;
@@ -179,6 +205,10 @@ public class Coordinator extends Channel implements AutoCloseable {
     } catch (Exception e) {
       LOG.warn("Commit failed, will try again next cycle", e);
     } finally {
+      // Clean up transaction state for the completed commit
+      if (commitState.currentCommitId() != null) {
+        commitTxIdsByTable.remove(commitState.currentCommitId());
+      }
       commitState.endCurrentCommit();
     }
   }
@@ -262,8 +292,15 @@ public class Coordinator extends Channel implements AutoCloseable {
     if (dataFiles.isEmpty() && deleteFiles.isEmpty()) {
       LOG.info("Nothing to commit to table {}, skipping", tableIdentifier);
     } else {
-      long txIdValidThrough = Utilities.calculateTxIdValidThrough(highestTxIdPerPartition());
-      long maxTxId = Utilities.getMaxTxId(highestTxIdPerPartition());
+      // Get transaction IDs for this specific commit and table
+      Map<TopicPartition, Long> tableHighestTxIds = getCommitTxIdsForTable(tableIdentifier);
+
+      LOG.info("TRACE: THIS Committing to table {}, commit ID {}, vtts {}, data files: {}, delete files: {}, highest txIds: {}",
+              tableIdentifier, commitState.currentCommitId(), vtts, dataFiles.size(), deleteFiles.size(), tableHighestTxIds);
+
+      long txIdValidThrough = Utilities.calculateTxIdValidThrough(tableHighestTxIds);
+      long maxTxId = Utilities.getMaxTxId(tableHighestTxIds);
+
       if (deleteFiles.isEmpty()) {
         Transaction transaction = table.newTransaction();
 
@@ -324,6 +361,24 @@ public class Coordinator extends Channel implements AutoCloseable {
           vtts);
     }
   }
+  /**
+   * Get the transaction IDs for a specific table in the current commit.
+   * This ensures we only use transaction data that belongs to the current commit.
+   */
+  private Map<TopicPartition, Long> getCommitTxIdsForTable(TableIdentifier tableIdentifier) {
+    if (commitState.currentCommitId() == null) {
+      return Collections.emptyMap();
+    }
+
+    Map<TableIdentifier, Map<TopicPartition, Long>> currentCommitTxIds =
+            commitTxIdsByTable.get(commitState.currentCommitId());
+
+    if (currentCommitTxIds == null) {
+      return Collections.emptyMap();
+    }
+
+    return currentCommitTxIds.getOrDefault(tableIdentifier, Collections.emptyMap());
+  }
 
   private void addTxDataToSnapshot(SnapshotUpdate<?> operation, long txIdValidThrough, long maxTxId) {
     if (txIdValidThrough > -1 && maxTxId > 0) {
@@ -364,6 +419,7 @@ public class Coordinator extends Channel implements AutoCloseable {
   @Override
   public void close() throws IOException {
     exec.shutdownNow();
+    commitTxIdsByTable.clear();
     stop();
   }
 }

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Coordinator.java
@@ -142,12 +142,8 @@ public class Coordinator extends Channel implements AutoCloseable {
             UUID commitId = payload.commitId();
             LOG.debug("Received transaction data complete event with {} txIds for commitId {} and here it is {}",
                     tableTxIds.size(), commitId, tableTxIds);
-            // Warn on duplicate commit IDs being received
             Map<TableIdentifier, Map<TopicPartition, Long>> currentCommitTxIds =
                     commitTxIdsByTable.computeIfAbsent(commitId, k -> Maps.newConcurrentMap());
-            if (currentCommitTxIds != commitTxIdsByTable.get(commitId)) {
-              LOG.warn("Commit ID {} already processed, consumed duplicate TransactionDataComplete.", commitId);
-            }
             tableTxIds.forEach(txId -> {
               TableIdentifier tableIdentifier = txId.tableIdentifier();
               TopicPartition tp = new TopicPartition(txId.topic(), txId.partition());

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/EventDecoder.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/EventDecoder.java
@@ -23,21 +23,19 @@ import io.tabular.iceberg.connect.events.CommitReadyPayload;
 import io.tabular.iceberg.connect.events.CommitRequestPayload;
 import io.tabular.iceberg.connect.events.CommitResponsePayload;
 import io.tabular.iceberg.connect.events.CommitTablePayload;
-
+import io.tabular.iceberg.connect.events.TableTopicPartitionTransaction;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import io.tabular.iceberg.connect.events.TopicPartitionTransaction;
 import io.tabular.iceberg.connect.events.TransactionDataComplete;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaParseException;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.avro.AvroSchemaUtil;
-import io.tabular.iceberg.connect.events.TopicPartitionTxId;
+import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.connect.events.AvroUtil;
 import org.apache.iceberg.connect.events.CommitComplete;
 import org.apache.iceberg.connect.events.CommitToTable;
@@ -100,6 +98,7 @@ public class EventDecoder {
     } else if (payload instanceof CommitReadyPayload) {
       CommitReadyPayload pay = (CommitReadyPayload) payload;
       List<io.tabular.iceberg.connect.events.TopicPartitionOffset> legacyTPO = pay.assignments();
+
       List<TopicPartitionOffset> converted =
           legacyTPO.stream()
               .map(
@@ -113,12 +112,17 @@ public class EventDecoder {
                               : OffsetDateTime.ofInstant(
                                   Instant.ofEpochMilli(t.timestamp()), ZoneOffset.UTC)))
               .collect(Collectors.toList());
-      List<TopicPartitionTxId> legacyTPT = pay.txIds();
-      List<TopicPartitionTransaction> convertedTxIds =
-          legacyTPT.stream()
-              .map(
-                  t -> new TopicPartitionTransaction(t.topic(), t.partition(), t.txId()))
-              .collect(Collectors.toList());
+
+      List<TableTopicPartitionTransaction> convertedTxIds =
+              pay.txIds().stream()
+                      .map(txId -> new TableTopicPartitionTransaction(
+                              txId.topic(),
+                              txId.partition(),
+                              catalogName,  // Use the catalogName from the decoder
+                              TableIdentifier.of("default"),  // Provide default or extract from payload
+                              txId.txId()))
+                      .collect(Collectors.toList());
+
       return new TransactionDataComplete(pay.commitId(), converted, convertedTxIds);
     } else if (payload instanceof CommitTablePayload) {
       CommitTablePayload pay = (CommitTablePayload) payload;

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Worker.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Worker.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -26,29 +26,32 @@ import io.tabular.iceberg.connect.data.Offset;
 import io.tabular.iceberg.connect.data.RecordWriter;
 import io.tabular.iceberg.connect.data.Utilities;
 import io.tabular.iceberg.connect.data.WriterResult;
+import io.tabular.iceberg.connect.events.TableTopicPartitionTransaction;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-// TODO: rename to WriterImpl later, minimize changes for clearer commit history for now
-class Worker implements Writer, AutoCloseable {
+class Worker implements Writer, AutoCloseable, CommittableSupplier {
 
   private static final Logger LOG = LoggerFactory.getLogger(Worker.class);
-  private static final String COL_TXID = "txid";
   private final IcebergSinkConfig config;
   private final IcebergWriterFactory writerFactory;
   private final Map<String, RecordWriter> writers;
   private final Map<TopicPartition, Offset> sourceOffsets;
-  private final Map<TopicPartition, Long> sourceTxIds;
 
   Worker(IcebergSinkConfig config, Catalog catalog) {
     this(config, new IcebergWriterFactory(catalog, config));
@@ -58,54 +61,76 @@ class Worker implements Writer, AutoCloseable {
   Worker(IcebergSinkConfig config, IcebergWriterFactory writerFactory) {
     this.config = config;
     this.writerFactory = writerFactory;
-    this.writers = Maps.newHashMap();
-    this.sourceOffsets = Maps.newHashMap();
-    this.sourceTxIds = Maps.newHashMap();
+    this.writers = Maps.newConcurrentMap();
+    this.sourceOffsets = Maps.newConcurrentMap();
   }
 
   @Override
-  public Committable committable() {
-    List<WriterResult> writeResults =
-        writers.values().stream().flatMap(writer -> writer.complete().stream()).collect(toList());
+  public synchronized Committable committable() {
+    List<WriterResult> writerResults =
+            writers.values().stream()
+                    .flatMap(writer -> writer.complete().stream())
+                    .collect(toList());
+
+    writerResults.forEach(res -> {
+      long totalRecords = res.dataFiles().stream().mapToLong(DataFile::recordCount).sum() +
+              res.deleteFiles().stream().mapToLong(DeleteFile::recordCount).sum();
+
+      LOG.debug("WriterResult for table {}: Total records = {}, TxID map = {}",
+              res.tableIdentifier(), totalRecords, res.partitionMaxTxids());
+    });
+
+    Map<TableIdentifier, Map<TopicPartition, Long>> aggregatedTxIds = Maps.newHashMap();
+    writerResults.forEach(res -> {
+      if (res.partitionMaxTxids() != null && !res.partitionMaxTxids().isEmpty()) {
+        Map<TopicPartition, Long> tableTxIds =
+                aggregatedTxIds.computeIfAbsent(res.tableIdentifier(), k -> Maps.newHashMap());
+        res.partitionMaxTxids()
+                .forEach((tp, txid) -> tableTxIds.merge(tp, txid, Long::max));
+      }
+    });
+
+    List<TableTopicPartitionTransaction> finalTableTxIds = Lists.newArrayList();
+    aggregatedTxIds.forEach((tableIdentifier, partitionTxIds) -> {
+      String catalogName = config.catalogName();
+      partitionTxIds.forEach((tp, txId) ->
+              finalTableTxIds.add(
+                      new TableTopicPartitionTransaction(
+                              tp.topic(), tp.partition(), catalogName, tableIdentifier, txId)));
+    });
+
+    LOG.info("Committable ready. Found {} transaction IDs from {} writer results.",
+            finalTableTxIds.size(), writerResults.size());
+
     Map<TopicPartition, Offset> offsets = Maps.newHashMap(sourceOffsets);
-    Map<TopicPartition, Long> txIds = Maps.newHashMap(sourceTxIds);
+    Committable result = new Committable(offsets, finalTableTxIds, writerResults);
 
     writers.clear();
     sourceOffsets.clear();
-    sourceTxIds.clear();
 
-    return new Committable(offsets, txIds, writeResults);
+    return result;
   }
 
   @Override
-  public void close() throws IOException {
+  public synchronized void close() throws IOException {
     writers.values().forEach(RecordWriter::close);
     writers.clear();
     sourceOffsets.clear();
-    sourceTxIds.clear();
   }
 
   @Override
-  public void write(Collection<SinkRecord> sinkRecords) {
+  public synchronized void write(Collection<SinkRecord> sinkRecords) {
     if (sinkRecords != null && !sinkRecords.isEmpty()) {
       sinkRecords.forEach(this::save);
     }
   }
 
-  private void save(SinkRecord record) {
+  private synchronized void save(SinkRecord record) {
     // the consumer stores the offsets that corresponds to the next record to consume,
     // so increment the record offset by one
     sourceOffsets.put(
         new TopicPartition(record.topic(), record.kafkaPartition()),
         new Offset(record.kafkaOffset() + 1, record.timestamp()));
-
-    Long txId = Utilities.extractTxIdFromRecordValue(record.value(), COL_TXID);
-    if (txId != null) {
-      LOG.debug("Found transaction id {} in record", txId);
-      sourceTxIds.put(
-          new TopicPartition(record.topic(), record.kafkaPartition()),
-          txId);
-    }
 
     if (config.dynamicTablesEnabled()) {
       routeRecordDynamically(record);

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/IcebergWriter.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/IcebergWriter.java
@@ -152,7 +152,8 @@ public class IcebergWriter implements RecordWriter {
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }
-
+    /* Pre-Filtering to align data written events with the filtering logic applied in the coordinator so our
+    TransactionDataComplete payload aligns with the data written events */
     long totalRecordCount = 0;
     if (writeResult.dataFiles() != null) {
       totalRecordCount += Arrays.stream(writeResult.dataFiles()).mapToLong(DataFile::recordCount).sum();

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/Utilities.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/Utilities.java
@@ -321,8 +321,11 @@ public class Utilities {
     // that is common across all partitions
     long minValue = Collections.min(highestTxIdPerPartition.values());
 
+    // If only one partition, return minValue directly.
     // Subtract 1 from the minimum value to get the last guaranteed completed transaction ID
-    // If minValue is 1, then there are no completed transactions, so return 0
+    if (highestTxIdPerPartition.size() == 1) {
+      return minValue;
+    }
     return minValue > 1 ? minValue - 1 : 0;
   }
 

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/WriterResult.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/WriterResult.java
@@ -19,10 +19,13 @@
 package io.tabular.iceberg.connect.data;
 
 import java.util.List;
+import java.util.Map;
+
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.types.Types.StructType;
+import org.apache.kafka.common.TopicPartition;
 
 public class WriterResult {
 
@@ -30,16 +33,19 @@ public class WriterResult {
   private final List<DataFile> dataFiles;
   private final List<DeleteFile> deleteFiles;
   private final StructType partitionStruct;
+  private final Map<TopicPartition, Long> partitionMaxTxids;
 
   public WriterResult(
       TableIdentifier tableIdentifier,
       List<DataFile> dataFiles,
       List<DeleteFile> deleteFiles,
-      StructType partitionStruct) {
+      StructType partitionStruct,
+      Map<TopicPartition, Long> partitionMaxTxids) {
     this.tableIdentifier = tableIdentifier;
     this.dataFiles = dataFiles;
     this.deleteFiles = deleteFiles;
     this.partitionStruct = partitionStruct;
+    this.partitionMaxTxids = partitionMaxTxids;
   }
 
   public TableIdentifier tableIdentifier() {
@@ -56,5 +62,9 @@ public class WriterResult {
 
   public StructType partitionStruct() {
     return partitionStruct;
+  }
+
+  public Map<TopicPartition, Long> partitionMaxTxids() {
+    return partitionMaxTxids;
   }
 }

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CommitStateTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CommitStateTest.java
@@ -28,7 +28,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.UUID;
 
-import io.tabular.iceberg.connect.events.TopicPartitionTransaction;
+import io.tabular.iceberg.connect.events.TableTopicPartitionTransaction;
 import io.tabular.iceberg.connect.events.TransactionDataComplete;
 import org.apache.iceberg.connect.events.Event;
 import org.apache.iceberg.connect.events.Payload;
@@ -45,7 +45,7 @@ public class CommitStateTest {
   @Test
   public void testIsCommitReady() {
     TopicPartitionOffset tp = mock(TopicPartitionOffset.class);
-    TopicPartitionTransaction tpt = mock(TopicPartitionTransaction.class);
+    TableTopicPartitionTransaction tpt = mock(TableTopicPartitionTransaction.class);
 
     CommitState commitState = new CommitState(mock(IcebergSinkConfig.class));
     commitState.startNewCommit();
@@ -53,17 +53,17 @@ public class CommitStateTest {
     TransactionDataComplete payload1 = mock(TransactionDataComplete.class);
     when(payload1.commitId()).thenReturn(commitState.currentCommitId());
     when(payload1.assignments()).thenReturn(ImmutableList.of(tp, tp));
-    when(payload1.txIds()).thenReturn(ImmutableList.of(tpt, tpt));
+    when(payload1.tableTxIds()).thenReturn(ImmutableList.of(tpt, tpt));
 
     TransactionDataComplete payload2 = mock(TransactionDataComplete.class);
     when(payload2.commitId()).thenReturn(commitState.currentCommitId());
     when(payload2.assignments()).thenReturn(ImmutableList.of(tp));
-    when(payload2.txIds()).thenReturn(ImmutableList.of(tpt));
+    when(payload2.tableTxIds()).thenReturn(ImmutableList.of(tpt));
 
     TransactionDataComplete payload3 = mock(TransactionDataComplete.class);
     when(payload3.commitId()).thenReturn(UUID.randomUUID());
     when(payload3.assignments()).thenReturn(ImmutableList.of(tp));
-    when(payload3.txIds()).thenReturn(ImmutableList.of(tpt));
+    when(payload3.tableTxIds()).thenReturn(ImmutableList.of(tpt));
 
     commitState.addReady(wrapInEnvelope(payload1));
     commitState.addReady(wrapInEnvelope(payload2));

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CoordinatorTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CoordinatorTest.java
@@ -103,7 +103,8 @@ public class CoordinatorTest extends ChannelTestBase {
     Assertions.assertEquals("{\"0\":3}", summary.get(OFFSETS_SNAPSHOT_PROP));
     Assertions.assertEquals(
             Long.toString(ts.toInstant().toEpochMilli()), summary.get(VTTS_SNAPSHOT_PROP));
-    Assertions.assertEquals(99L, Long.valueOf(summary.get(TX_ID_VALID_THROUGH_PROP)));
+    // 100 now as single partition
+    Assertions.assertEquals(100L, Long.valueOf(summary.get(TX_ID_VALID_THROUGH_PROP)));
     Assertions.assertEquals(100L, Long.valueOf(summary.get(MAX_TX_ID_PROP)));
   }
 
@@ -239,7 +240,8 @@ public class CoordinatorTest extends ChannelTestBase {
     Assertions.assertEquals(1, ImmutableList.copyOf(snapshot.addedDataFiles(table.io())).size());
     Assertions.assertEquals(0, ImmutableList.copyOf(snapshot.addedDeleteFiles(table.io())).size());
     Map<String, String> summary = snapshot.summary();
-    Assertions.assertEquals(99L, Long.valueOf(summary.get(TX_ID_VALID_THROUGH_PROP)));
+    // 100 now as single partition
+    Assertions.assertEquals(100L, Long.valueOf(summary.get(TX_ID_VALID_THROUGH_PROP)));
     Assertions.assertEquals(100L, Long.valueOf(summary.get(MAX_TX_ID_PROP)));
   }
 

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CoordinatorTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CoordinatorTest.java
@@ -21,7 +21,7 @@ package io.tabular.iceberg.connect.channel;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-import io.tabular.iceberg.connect.events.TopicPartitionTransaction;
+import io.tabular.iceberg.connect.events.TableTopicPartitionTransaction;
 import io.tabular.iceberg.connect.events.TransactionDataComplete;
 import io.tabular.iceberg.connect.fixtures.EventTestUtil;
 import java.time.Instant;
@@ -42,6 +42,7 @@ import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.connect.events.AvroUtil;
 import org.apache.iceberg.connect.events.CommitComplete;
 import org.apache.iceberg.connect.events.CommitToTable;
@@ -66,20 +67,26 @@ import org.junit.jupiter.api.Test;
 
 public class CoordinatorTest extends ChannelTestBase {
 
+  // The property name for max-tx-id has a typo in the original test, correcting it here
+  private static final String MAX_TX_ID_PROP = "txid-max";
+
   @Test
   public void testCommitAppend() {
     Assertions.assertEquals(0, ImmutableList.copyOf(table.snapshots().iterator()).size());
 
-    List<TopicPartitionTransaction> transactionsProcessed =
-            ImmutableList.of(new TopicPartitionTransaction("topic", 1, 100L));
+    // CHANGED: Use the new transaction object, including the table reference
+    TableReference tableRef = TableReference.of("catalog", TABLE_IDENTIFIER);
+    List<TableTopicPartitionTransaction> transactionsProcessed =
+            ImmutableList.of(new TableTopicPartitionTransaction("topic", 1, "catalog", TABLE_IDENTIFIER, 100L));
+
     OffsetDateTime ts = OffsetDateTime.ofInstant(Instant.now(), ZoneOffset.UTC);
     UUID commitId =
-        coordinatorTest(ImmutableList.of(EventTestUtil.createDataFile()), ImmutableList.of(), ts, transactionsProcessed);
+            coordinatorTest(ImmutableList.of(EventTestUtil.createDataFile()), ImmutableList.of(), ts, transactionsProcessed);
     table.refresh();
 
     assertThat(producer.history()).hasSize(3);
     assertThat(consumer.committed(ImmutableSet.of(CTL_TOPIC_PARTITION)))
-        .isEqualTo(ImmutableMap.of(CTL_TOPIC_PARTITION, new OffsetAndMetadata(3L)));
+            .isEqualTo(ImmutableMap.of(CTL_TOPIC_PARTITION, new OffsetAndMetadata(3L)));
     assertCommitTable(1, commitId, ts);
     assertCommitComplete(2, commitId, ts);
 
@@ -95,32 +102,36 @@ public class CoordinatorTest extends ChannelTestBase {
     Assertions.assertEquals(commitId.toString(), summary.get(COMMIT_ID_SNAPSHOT_PROP));
     Assertions.assertEquals("{\"0\":3}", summary.get(OFFSETS_SNAPSHOT_PROP));
     Assertions.assertEquals(
-        Long.toString(ts.toInstant().toEpochMilli()), summary.get(VTTS_SNAPSHOT_PROP));
-    Assertions.assertEquals(transactionsProcessed.get(0).txId() - 1, Long.valueOf(summary.get(TX_ID_VALID_THROUGH_PROP)));
-    Assertions.assertEquals(transactionsProcessed.get(0).txId(), Long.valueOf(summary.get(MAX_TX_ID__PROP)));
+            Long.toString(ts.toInstant().toEpochMilli()), summary.get(VTTS_SNAPSHOT_PROP));
+    Assertions.assertEquals(99L, Long.valueOf(summary.get(TX_ID_VALID_THROUGH_PROP)));
+    Assertions.assertEquals(100L, Long.valueOf(summary.get(MAX_TX_ID_PROP)));
   }
 
   @Test
   public void testCommitDelta() {
-    List<TopicPartitionTransaction> transactionsProcessed =
-            ImmutableList.of(new TopicPartitionTransaction("topic", 1, 100L),
-            new TopicPartitionTransaction("topic", 2, 102L),
-            new TopicPartitionTransaction("topic", 3, 101L),
-            new TopicPartitionTransaction("topic", 3, 102L),
-            new TopicPartitionTransaction("topic", 3, 100L),
-            new TopicPartitionTransaction("topic", 3, 103L),
-            new TopicPartitionTransaction("topic", 4, 104L));
+    // CHANGED: Use the new transaction object
+    TableReference tableRef = TableReference.of("catalog", TABLE_IDENTIFIER);
+    List<TableTopicPartitionTransaction> transactionsProcessed =
+            ImmutableList.of(
+                    new TableTopicPartitionTransaction("topic", 1, "catalog", TABLE_IDENTIFIER, 100L),
+                    new TableTopicPartitionTransaction("topic", 2, "catalog", TABLE_IDENTIFIER, 102L),
+                    new TableTopicPartitionTransaction("topic", 3, "catalog", TABLE_IDENTIFIER, 101L),
+                    new TableTopicPartitionTransaction("topic", 3, "catalog", TABLE_IDENTIFIER, 102L),
+                    new TableTopicPartitionTransaction("topic", 3, "catalog", TABLE_IDENTIFIER, 100L),
+                    new TableTopicPartitionTransaction("topic", 3, "catalog", TABLE_IDENTIFIER, 103L),
+                    new TableTopicPartitionTransaction("topic", 4, "catalog", TABLE_IDENTIFIER, 104L));
+
     OffsetDateTime ts = OffsetDateTime.ofInstant(Instant.now(), ZoneOffset.UTC);
     UUID commitId =
-        coordinatorTest(
-            ImmutableList.of(EventTestUtil.createDataFile()),
-            ImmutableList.of(EventTestUtil.createDeleteFile()),
-            ts,
-            transactionsProcessed);
+            coordinatorTest(
+                    ImmutableList.of(EventTestUtil.createDataFile()),
+                    ImmutableList.of(EventTestUtil.createDeleteFile()),
+                    ts,
+                    transactionsProcessed);
 
     assertThat(producer.history()).hasSize(3);
     assertThat(consumer.committed(ImmutableSet.of(CTL_TOPIC_PARTITION)))
-        .isEqualTo(ImmutableMap.of(CTL_TOPIC_PARTITION, new OffsetAndMetadata(3L)));
+            .isEqualTo(ImmutableMap.of(CTL_TOPIC_PARTITION, new OffsetAndMetadata(3L)));
     assertCommitTable(1, commitId, ts);
     assertCommitComplete(2, commitId, ts);
 
@@ -136,9 +147,9 @@ public class CoordinatorTest extends ChannelTestBase {
     Assertions.assertEquals(commitId.toString(), summary.get(COMMIT_ID_SNAPSHOT_PROP));
     Assertions.assertEquals("{\"0\":3}", summary.get(OFFSETS_SNAPSHOT_PROP));
     Assertions.assertEquals(
-        Long.toString(ts.toInstant().toEpochMilli()), summary.get(VTTS_SNAPSHOT_PROP));
+            Long.toString(ts.toInstant().toEpochMilli()), summary.get(VTTS_SNAPSHOT_PROP));
     Assertions.assertEquals(99L, Long.valueOf(summary.get(TX_ID_VALID_THROUGH_PROP)));
-    Assertions.assertEquals(104L, Long.valueOf(summary.get(MAX_TX_ID__PROP)));
+    Assertions.assertEquals(104L, Long.valueOf(summary.get(MAX_TX_ID_PROP)));
   }
 
   @Test
@@ -148,7 +159,7 @@ public class CoordinatorTest extends ChannelTestBase {
 
     assertThat(producer.history()).hasSize(2);
     assertThat(consumer.committed(ImmutableSet.of(CTL_TOPIC_PARTITION)))
-        .isEqualTo(ImmutableMap.of(CTL_TOPIC_PARTITION, new OffsetAndMetadata(3L)));
+            .isEqualTo(ImmutableMap.of(CTL_TOPIC_PARTITION, new OffsetAndMetadata(3L)));
     assertCommitComplete(1, commitId, ts);
 
     List<Snapshot> snapshots = ImmutableList.copyOf(table.snapshots());
@@ -159,25 +170,25 @@ public class CoordinatorTest extends ChannelTestBase {
   public void testCommitError() {
     // this spec isn't registered with the table
     PartitionSpec badPartitionSpec =
-        PartitionSpec.builderFor(SCHEMA).withSpecId(1).identity("id").build();
+            PartitionSpec.builderFor(SCHEMA).withSpecId(1).identity("id").build();
     DataFile badDataFile =
-        DataFiles.builder(badPartitionSpec)
-            .withPath(UUID.randomUUID() + ".parquet")
-            .withFormat(FileFormat.PARQUET)
-            .withFileSizeInBytes(100L)
-            .withRecordCount(5)
-            .build();
+            DataFiles.builder(badPartitionSpec)
+                    .withPath(UUID.randomUUID() + ".parquet")
+                    .withFormat(FileFormat.PARQUET)
+                    .withFileSizeInBytes(100L)
+                    .withRecordCount(5)
+                    .build();
 
     coordinatorTest(
-        ImmutableList.of(badDataFile),
-        ImmutableList.of(),
-        OffsetDateTime.ofInstant(Instant.ofEpochMilli(0L), ZoneOffset.UTC),
-        ImmutableList.of());
+            ImmutableList.of(badDataFile),
+            ImmutableList.of(),
+            OffsetDateTime.ofInstant(Instant.ofEpochMilli(0L), ZoneOffset.UTC),
+            ImmutableList.of());
 
     // no commit messages sent
     assertThat(producer.history()).hasSize(1);
     assertThat(consumer.committed(ImmutableSet.of(CTL_TOPIC_PARTITION)))
-        .isEqualTo(ImmutableMap.of());
+            .isEqualTo(ImmutableMap.of());
 
     List<Snapshot> snapshots = ImmutableList.copyOf(table.snapshots());
     Assertions.assertEquals(0, snapshots.size());
@@ -185,34 +196,37 @@ public class CoordinatorTest extends ChannelTestBase {
 
   @Test
   public void testShouldDeduplicateDataFilesBeforeAppending() {
-    List<TopicPartitionTransaction> transactionsProcessed =
-            ImmutableList.of(new TopicPartitionTransaction("topic", 1, 100L));
+    // CHANGED: Use the new transaction object
+    TableReference tableRef = TableReference.of("catalog", TableIdentifier.of("db", "tbl"));
+    List<TableTopicPartitionTransaction> transactionsProcessed =
+            ImmutableList.of(new TableTopicPartitionTransaction("topic", 1, "catalog", TABLE_IDENTIFIER, 100L));
+
     OffsetDateTime ts = OffsetDateTime.ofInstant(Instant.now(), ZoneOffset.UTC);
     DataFile dataFile = EventTestUtil.createDataFile();
 
     UUID commitId =
-        coordinatorTest(
-            currentCommitId -> {
-              Event commitResponse =
-                  new Event(
-                      config.controlGroupId(),
-                      new DataWritten(
-                          StructType.of(),
-                          currentCommitId,
-                          new TableReference("catalog", ImmutableList.of("db"), "tbl"),
-                          ImmutableList.of(dataFile, dataFile), // duplicated data files
-                          ImmutableList.of()));
+            coordinatorTest(
+                    currentCommitId -> {
+                      Event commitResponse =
+                              new Event(
+                                      config.controlGroupId(),
+                                      new DataWritten(
+                                              StructType.of(),
+                                              currentCommitId,
+                                              tableRef,
+                                              ImmutableList.of(dataFile, dataFile), // duplicated data files
+                                              ImmutableList.of()));
 
-              return ImmutableList.of(
-                  commitResponse,
-                  commitResponse, // duplicate commit response
-                  new Event(
-                      config.controlGroupId(),
-                      new TransactionDataComplete(
-                          currentCommitId,
-                          ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L, ts)),
-                          transactionsProcessed)));
-            });
+                      return ImmutableList.of(
+                              commitResponse,
+                              commitResponse, // duplicate commit response
+                              new Event(
+                                      config.controlGroupId(),
+                                      new TransactionDataComplete(
+                                              currentCommitId,
+                                              ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L, ts)),
+                                              transactionsProcessed)));
+                    });
 
     assertCommitTable(1, commitId, ts);
     assertCommitComplete(2, commitId, ts);
@@ -225,8 +239,8 @@ public class CoordinatorTest extends ChannelTestBase {
     Assertions.assertEquals(1, ImmutableList.copyOf(snapshot.addedDataFiles(table.io())).size());
     Assertions.assertEquals(0, ImmutableList.copyOf(snapshot.addedDeleteFiles(table.io())).size());
     Map<String, String> summary = snapshot.summary();
-    Assertions.assertEquals(transactionsProcessed.get(0).txId() - 1, Long.valueOf(summary.get(TX_ID_VALID_THROUGH_PROP)));
-    Assertions.assertEquals(transactionsProcessed.get(0).txId(), Long.valueOf(summary.get(MAX_TX_ID__PROP)));
+    Assertions.assertEquals(99L, Long.valueOf(summary.get(TX_ID_VALID_THROUGH_PROP)));
+    Assertions.assertEquals(100L, Long.valueOf(summary.get(MAX_TX_ID_PROP)));
   }
 
   @Test
@@ -234,29 +248,32 @@ public class CoordinatorTest extends ChannelTestBase {
     OffsetDateTime ts = OffsetDateTime.ofInstant(Instant.now(), ZoneOffset.UTC);
     DeleteFile deleteFile = EventTestUtil.createDeleteFile();
 
-    UUID commitId =
-        coordinatorTest(
-            currentCommitId -> {
-              Event duplicateCommitResponse =
-                  new Event(
-                      config.controlGroupId(),
-                      new DataWritten(
-                          StructType.of(),
-                          currentCommitId,
-                          new TableReference("catalog", ImmutableList.of("db"), "tbl"),
-                          ImmutableList.of(),
-                          ImmutableList.of(deleteFile, deleteFile))); // duplicate delete files
+    // CHANGED: Use the new transaction object
+    TableReference tableRef = TableReference.of("catalog", TableIdentifier.of("db", "tbl"));
 
-              return ImmutableList.of(
-                  duplicateCommitResponse,
-                  duplicateCommitResponse, // duplicate commit response
-                  new Event(
-                      config.controlGroupId(),
-                          new TransactionDataComplete(
-                                  currentCommitId,
-                                  ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L, ts)),
-                                  ImmutableList.of(new TopicPartitionTransaction("topic", 1, 100L)))));
-            });
+    UUID commitId =
+            coordinatorTest(
+                    currentCommitId -> {
+                      Event duplicateCommitResponse =
+                              new Event(
+                                      config.controlGroupId(),
+                                      new DataWritten(
+                                              StructType.of(),
+                                              currentCommitId,
+                                              tableRef,
+                                              ImmutableList.of(),
+                                              ImmutableList.of(deleteFile, deleteFile))); // duplicate delete files
+
+                      return ImmutableList.of(
+                              duplicateCommitResponse,
+                              duplicateCommitResponse, // duplicate commit response
+                              new Event(
+                                      config.controlGroupId(),
+                                      new TransactionDataComplete(
+                                              currentCommitId,
+                                              ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L, ts)),
+                                              ImmutableList.of(new TableTopicPartitionTransaction("topic", 1, "catalog", TABLE_IDENTIFIER, 100L)))));
+                    });
 
     assertCommitTable(1, commitId, ts);
     assertCommitComplete(2, commitId, ts);
@@ -271,29 +288,32 @@ public class CoordinatorTest extends ChannelTestBase {
   }
 
   private void validateAddedFiles(
-      Snapshot snapshot, Set<String> expectedDataFilePaths, PartitionSpec expectedSpec) {
+          Snapshot snapshot, Set<String> expectedDataFilePaths, PartitionSpec expectedSpec) {
     final List<DataFile> addedDataFiles = ImmutableList.copyOf(snapshot.addedDataFiles(table.io()));
     final List<DeleteFile> addedDeleteFiles =
-        ImmutableList.copyOf(snapshot.addedDeleteFiles(table.io()));
+            ImmutableList.copyOf(snapshot.addedDeleteFiles(table.io()));
 
     Assertions.assertEquals(
-        expectedDataFilePaths,
-        addedDataFiles.stream().map(ContentFile::path).collect(Collectors.toSet()));
+            expectedDataFilePaths,
+            addedDataFiles.stream().map(ContentFile::path).collect(Collectors.toSet()));
 
     Assertions.assertEquals(
-        ImmutableSet.of(expectedSpec.specId()),
-        Stream.concat(addedDataFiles.stream(), addedDeleteFiles.stream())
-            .map(ContentFile::specId)
-            .collect(Collectors.toSet()));
+            ImmutableSet.of(expectedSpec.specId()),
+            Stream.concat(addedDataFiles.stream(), addedDeleteFiles.stream())
+                    .map(ContentFile::specId)
+                    .collect(Collectors.toSet()));
   }
 
   @Test
   public void testTxIdValidThroughInSnapshotSummary() {
     Assertions.assertEquals(0, ImmutableList.copyOf(table.snapshots().iterator()).size());
 
+    // CHANGED: This test now uses the richer object directly
+    TableReference tableRef = TableReference.of("catalog", TABLE_IDENTIFIER);
     Map<TopicPartition, Long> txIdPerPartition = ImmutableMap.of(
             new TopicPartition("topic", 1), 100L,
             new TopicPartition("topic", 2), 102L);
+
     OffsetDateTime ts = OffsetDateTime.ofInstant(Instant.now(), ZoneOffset.UTC);
     UUID commitId =
             coordinatorTxIdValidThroughTest(ImmutableList.of(EventTestUtil.createDataFile()), ImmutableList.of(), ts, txIdPerPartition);
@@ -319,21 +339,9 @@ public class CoordinatorTest extends ChannelTestBase {
     Assertions.assertEquals(
             Long.toString(ts.toInstant().toEpochMilli()), summary.get(VTTS_SNAPSHOT_PROP));
     Assertions.assertEquals(99L, Long.valueOf(summary.get(TX_ID_VALID_THROUGH_PROP)));
-    Assertions.assertEquals(102L, Long.valueOf(summary.get(MAX_TX_ID__PROP)));
+    Assertions.assertEquals(102L, Long.valueOf(summary.get(MAX_TX_ID_PROP)));
   }
 
-  /**
-   *
-   *
-   * <ul>
-   *   <li>Sets up an empty table with 2 partition specs
-   *   <li>Starts a coordinator with 2 worker assignment each handling a different topic-partition
-   *   <li>Sends a commit request to workers
-   *   <li>Each worker writes datafiles with a different partition spec
-   *   <li>The coordinator receives datafiles from both workers eventually and commits them to the
-   *       table
-   * </ul>
-   */
   @Test
   public void testCommitMultiPartitionSpecAppendDataFiles() {
     final PartitionSpec spec1 = table.spec();
@@ -349,95 +357,92 @@ public class CoordinatorTest extends ChannelTestBase {
     final List<MemberDescription> members = Lists.newArrayList();
     for (int i : ImmutableList.of(0, 1)) {
       members.add(
-          new MemberDescription(
-              "memberId" + i,
-              "clientId" + i,
-              "host" + i,
-              new MemberAssignment(ImmutableSet.of(new TopicPartition(SRC_TOPIC_NAME, i)))));
+              new MemberDescription(
+                      "memberId" + i,
+                      "clientId" + i,
+                      "host" + i,
+                      new MemberAssignment(ImmutableSet.of(new TopicPartition(SRC_TOPIC_NAME, i)))));
     }
 
     final Coordinator coordinator = new Coordinator(catalog, config, members, clientFactory);
     initConsumer();
 
-    // start a new commit immediately and wait for all workers to respond infinitely
     when(config.commitIntervalMs()).thenReturn(0);
     when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
     coordinator.process();
 
-    // retrieve commitId from commit request produced by coordinator
     final byte[] bytes = producer.history().get(0).value();
     final Event commitRequest = AvroUtil.decode(bytes);
     assert commitRequest.type().equals(PayloadType.START_COMMIT);
     final UUID commitId = ((StartCommit) commitRequest.payload()).commitId();
 
-    // each worker sends its responses for the commit request
     Map<Integer, PartitionSpec> workerIdToSpecMap =
-        ImmutableMap.of(
-            1, spec1, // worker 1 produces datafiles with the old partition spec
-            2, spec2 // worker 2 produces datafiles with the new partition spec
+            ImmutableMap.of(
+                    1, spec1,
+                    2, spec2
             );
 
+    // CHANGED: Use the new transaction object
+    TableReference tableRef = TableReference.of("catalog", TABLE_IDENTIFIER);
     int currentControlTopicOffset = 1;
     for (Map.Entry<Integer, PartitionSpec> entry : workerIdToSpecMap.entrySet()) {
       Integer workerId = entry.getKey();
       PartitionSpec spec = entry.getValue();
 
       final DataFile dataFile =
-          DataFiles.builder(spec)
-              .withPath(String.format("file%d.parquet", workerId))
-              .withFileSizeInBytes(100)
-              .withRecordCount(5)
-              .build();
+              DataFiles.builder(spec)
+                      .withPath(String.format("file%d.parquet", workerId))
+                      .withFileSizeInBytes(100)
+                      .withRecordCount(5)
+                      .build();
 
       consumer.addRecord(
-          new ConsumerRecord<>(
-              CTL_TOPIC_NAME,
-              0,
-              currentControlTopicOffset,
-              "key",
-              AvroUtil.encode(
-                  new Event(
-                      config.controlGroupId(),
-                      new DataWritten(
-                          spec.partitionType(),
-                          commitId,
-                          TableReference.of("catalog", TABLE_IDENTIFIER),
-                          ImmutableList.of(dataFile),
-                          ImmutableList.of())))));
+              new ConsumerRecord<>(
+                      CTL_TOPIC_NAME,
+                      0,
+                      currentControlTopicOffset,
+                      "key",
+                      AvroUtil.encode(
+                              new Event(
+                                      config.controlGroupId(),
+                                      new DataWritten(
+                                              spec.partitionType(),
+                                              commitId,
+                                              tableRef,
+                                              ImmutableList.of(dataFile),
+                                              ImmutableList.of())))));
       currentControlTopicOffset += 1;
 
       consumer.addRecord(
-          new ConsumerRecord<>(
-              CTL_TOPIC_NAME,
-              0,
-              currentControlTopicOffset,
-              "key",
-              AvroUtil.encode(
-                  new Event(
-                      config.controlGroupId(),
-                      new TransactionDataComplete(
-                          commitId,
-                          ImmutableList.of(
-                              new TopicPartitionOffset(
-                                  SRC_TOPIC_NAME,
-                                  0,
-                                  100L,
-                                  OffsetDateTime.ofInstant(
-                                      Instant.ofEpochMilli(100L), ZoneOffset.UTC))),
-                              ImmutableList.of(
-                                  new TopicPartitionTransaction(SRC_TOPIC_NAME, 0, 100L),
-                                  new TopicPartitionTransaction(SRC_TOPIC_NAME, 1, 110L),
-                                      new TopicPartitionTransaction(SRC_TOPIC_NAME, 2, 102L)))))));
+              new ConsumerRecord<>(
+                      CTL_TOPIC_NAME,
+                      0,
+                      currentControlTopicOffset,
+                      "key",
+                      AvroUtil.encode(
+                              new Event(
+                                      config.controlGroupId(),
+                                      new TransactionDataComplete(
+                                              commitId,
+                                              ImmutableList.of(
+                                                      new TopicPartitionOffset(
+                                                              SRC_TOPIC_NAME,
+                                                              0,
+                                                              100L,
+                                                              OffsetDateTime.ofInstant(
+                                                                      Instant.ofEpochMilli(100L), ZoneOffset.UTC))),
+                                              ImmutableList.of(
+                                                      new TableTopicPartitionTransaction(SRC_TOPIC_NAME, 0, "catalog", TABLE_IDENTIFIER, 100L),
+                                                      new TableTopicPartitionTransaction(SRC_TOPIC_NAME, 1, "catalog", TABLE_IDENTIFIER, 110L),
+                                                      new TableTopicPartitionTransaction(SRC_TOPIC_NAME, 2, "catalog", TABLE_IDENTIFIER, 102L)))))));
       currentControlTopicOffset += 1;
     }
 
-    // all workers have responded so coordinator can process responses now
     coordinator.process();
 
-    // assertions
     table.refresh();
     final List<Snapshot> snapshots = ImmutableList.copyOf(table.snapshots());
-    Assertions.assertEquals(2, snapshots.size(), "Expected 2 snapshots, one for each spec.");
+    Assertions.assertEquals(2, snapshots.size());
 
     final Snapshot firstSnapshot = snapshots.get(0);
     final Snapshot secondSnapshot = snapshots.get(1);
@@ -445,36 +450,15 @@ public class CoordinatorTest extends ChannelTestBase {
     validateAddedFiles(firstSnapshot, ImmutableSet.of("file1.parquet"), spec1);
     validateAddedFiles(secondSnapshot, ImmutableSet.of("file2.parquet"), spec2);
 
-    Assertions.assertEquals(
-        commitId.toString(),
-        firstSnapshot.summary().get(COMMIT_ID_SNAPSHOT_PROP),
-        "All snapshots should be tagged with a commit-id");
-    Assertions.assertNull(
-        firstSnapshot.summary().getOrDefault(OFFSETS_SNAPSHOT_PROP, null),
-        "Earlier snapshots should not include control-topic-offsets in their summary");
-    Assertions.assertNull(
-        firstSnapshot.summary().getOrDefault(VTTS_SNAPSHOT_PROP, null),
-        "Earlier snapshots should not include vtts in their summary");
+    Assertions.assertEquals(commitId.toString(), firstSnapshot.summary().get(COMMIT_ID_SNAPSHOT_PROP));
+    Assertions.assertNull(firstSnapshot.summary().getOrDefault(OFFSETS_SNAPSHOT_PROP, null));
+    Assertions.assertNull(firstSnapshot.summary().getOrDefault(VTTS_SNAPSHOT_PROP, null));
 
-    Assertions.assertEquals(
-        commitId.toString(),
-        secondSnapshot.summary().get(COMMIT_ID_SNAPSHOT_PROP),
-        "All snapshots should be tagged with a commit-id");
-    Assertions.assertEquals(
-        "{\"0\":5}",
-        secondSnapshot.summary().get(OFFSETS_SNAPSHOT_PROP),
-        "Only the most recent snapshot should include control-topic-offsets in it's summary");
-    Assertions.assertEquals(
-        "100",
-        secondSnapshot.summary().get(VTTS_SNAPSHOT_PROP),
-        "Only the most recent snapshot should include vtts in it's summary");
-    Assertions.assertEquals(
-            99L,
-            Long.valueOf(secondSnapshot.summary().get(TX_ID_VALID_THROUGH_PROP)),
-            "The lowest txId processed by all workers -1 should be the txId valid through");
-    Assertions.assertEquals(110L,
-            Long.valueOf(secondSnapshot.summary().get(MAX_TX_ID__PROP)),
-            "Max txId processed by all workers should be the max txId");
+    Assertions.assertEquals(commitId.toString(), secondSnapshot.summary().get(COMMIT_ID_SNAPSHOT_PROP));
+    Assertions.assertEquals("{\"0\":5}", secondSnapshot.summary().get(OFFSETS_SNAPSHOT_PROP));
+    Assertions.assertEquals("100", secondSnapshot.summary().get(VTTS_SNAPSHOT_PROP));
+    Assertions.assertEquals(99L, Long.valueOf(secondSnapshot.summary().get(TX_ID_VALID_THROUGH_PROP)));
+    Assertions.assertEquals(110L, Long.valueOf(secondSnapshot.summary().get(MAX_TX_ID_PROP)));
   }
 
   private void assertCommitTable(int idx, UUID commitId, OffsetDateTime ts) {
@@ -484,7 +468,7 @@ public class CoordinatorTest extends ChannelTestBase {
     CommitToTable commitTablePayload = (CommitToTable) commitTable.payload();
     assertThat(commitTablePayload.commitId()).isEqualTo(commitId);
     assertThat(commitTablePayload.tableReference().identifier().toString())
-        .isEqualTo(TABLE_IDENTIFIER.toString());
+            .isEqualTo(TABLE_IDENTIFIER.toString());
     assertThat(commitTablePayload.validThroughTs()).isEqualTo(ts);
   }
 
@@ -497,32 +481,34 @@ public class CoordinatorTest extends ChannelTestBase {
     assertThat(commitCompletePayload.validThroughTs()).isEqualTo(ts);
   }
 
+  // CHANGED: Helper method signature and implementation
   private UUID coordinatorTest(
-      List<DataFile> dataFiles, List<DeleteFile> deleteFiles, OffsetDateTime ts, List<TopicPartitionTransaction> transactionsProcessed) {
+          List<DataFile> dataFiles, List<DeleteFile> deleteFiles, OffsetDateTime ts, List<TableTopicPartitionTransaction> transactionsProcessed) {
     return coordinatorTest(
-        currentCommitId -> {
-          Event commitResponse =
-              new Event(
-                  config.controlGroupId(),
-                  new DataWritten(
-                      StructType.of(),
-                      currentCommitId,
-                      new TableReference("catalog", ImmutableList.of("db"), "tbl"),
-                      dataFiles,
-                      deleteFiles));
+            currentCommitId -> {
+              Event commitResponse =
+                      new Event(
+                              config.controlGroupId(),
+                              new DataWritten(
+                                      StructType.of(),
+                                      currentCommitId,
+                                      TableReference.of("catalog", TableIdentifier.of("db", "tbl")),
+                                      dataFiles,
+                                      deleteFiles));
 
-          Event commitReady =
-              new Event(
-                  config.controlGroupId(),
-                  new TransactionDataComplete(
-                      currentCommitId,
-                      ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L, ts)),
-                         transactionsProcessed));
+              Event commitReady =
+                      new Event(
+                              config.controlGroupId(),
+                              new TransactionDataComplete(
+                                      currentCommitId,
+                                      ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L, ts)),
+                                      transactionsProcessed));
 
-          return ImmutableList.of(commitResponse, commitReady);
-        });
+              return ImmutableList.of(commitResponse, commitReady);
+            });
   }
 
+  // CHANGED: Helper method implementation
   private UUID coordinatorTxIdValidThroughTest(
           List<DataFile> dataFiles, List<DeleteFile> deleteFiles, OffsetDateTime ts, Map<TopicPartition, Long> txIdPerPartition) {
     return coordinatorTest(
@@ -533,9 +519,14 @@ public class CoordinatorTest extends ChannelTestBase {
                               new DataWritten(
                                       StructType.of(),
                                       currentCommitId,
-                                      new TableReference("catalog", ImmutableList.of("db"), "tbl"),
+                                      TableReference.of("catalog", TableIdentifier.of("db", "tbl")),
                                       dataFiles,
                                       deleteFiles));
+
+              TableReference tableRef = TableReference.of("catalog", TableIdentifier.of("db", "tbl"));
+              List<TableTopicPartitionTransaction> tableTxIds = txIdPerPartition.entrySet().stream()
+                      .map(entry -> new TableTopicPartitionTransaction(entry.getKey().topic(), entry.getKey().partition(), "catalog", TABLE_IDENTIFIER, entry.getValue()))
+                      .collect(Collectors.toList());
 
               Event commitReady =
                       new Event(
@@ -543,9 +534,7 @@ public class CoordinatorTest extends ChannelTestBase {
                               new TransactionDataComplete(
                                       currentCommitId,
                                       ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L, ts)),
-                                      txIdPerPartition.entrySet().stream()
-                                              .map(entry -> new TopicPartitionTransaction(entry.getKey().topic(), entry.getKey().partition(), entry.getValue()))
-                                              .collect(Collectors.toList())));
+                                      tableTxIds));
 
               return ImmutableList.of(commitResponse, commitReady);
             });
@@ -557,9 +546,7 @@ public class CoordinatorTest extends ChannelTestBase {
 
     Coordinator coordinator = new Coordinator(catalog, config, ImmutableList.of(), clientFactory);
 
-    // init consumer after subscribe()
     initConsumer();
-
     coordinator.process();
 
     assertThat(producer.transactionCommitted()).isTrue();
@@ -579,7 +566,6 @@ public class CoordinatorTest extends ChannelTestBase {
     }
 
     when(config.commitIntervalMs()).thenReturn(0);
-
     coordinator.process();
 
     return commitId;

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/EventDecoderTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/EventDecoderTest.java
@@ -219,13 +219,15 @@ public class EventDecoderTest {
     assertThat(payload.assignments().get(1).offset()).isNull();
     assertThat(payload.assignments().get(1).timestamp()).isNull();
 
-    assertThat(payload.txIds().get(0).topic()).isEqualTo("topic");
-    assertThat(payload.txIds().get(0).partition()).isEqualTo(1);
-    assertThat(payload.txIds().get(0).txId()).isEqualTo(1L);
+    assertThat(payload.tableTxIds()).isNotEmpty();
+    assertThat(payload.tableTxIds().size()).isEqualTo(2);
+    assertThat(payload.tableTxIds().get(0).topic()).isEqualTo("topic");
+    assertThat(payload.tableTxIds().get(0).partition()).isEqualTo(1);
+    assertThat(payload.tableTxIds().get(0).txId()).isEqualTo(1L);
 
-    assertThat(payload.txIds().get(1).topic()).isEqualTo("topic");
-    assertThat(payload.txIds().get(1).partition()).isEqualTo(2);
-    assertThat(payload.txIds().get(1).txId()).isNull();
+    assertThat(payload.tableTxIds().get(1).topic()).isEqualTo("topic");
+    assertThat(payload.tableTxIds().get(1).partition()).isEqualTo(2);
+    assertThat(payload.tableTxIds().get(1).txId()).isNull();
   }
 
   @Test


### PR DESCRIPTION
This commit refactors the calculation logic for `txid-valid-through` and `max-txid` metadata to address inaccuracies and improve robustness.

The previous implementation could lead to incorrect metadata under certain conditions. This refactor introduces a more precise and thread-safe approach.

Key changes:

- **New TXID Tracking Map:** Introduced a new map with the structure `commit uuid -> table name -> topic partition object -> txid` for more granular and accurate transaction ID tracking.

- **Table Context Propagation:** A new class was created to pass the table object into the coordinator's context. This provides the necessary table-level information for the new mapping. Dependent classes were updated to use this new context.

- **Centralized TXID Extraction:** The responsibility for extracting transaction IDs has been moved to the Iceberg writer class. The extracted `txid`s are now passed back within the written data results, streamlining the data flow.

- **Thread Safety:** Implemented additional synchronization to ensure the new data structures are managed safely in a multi-threaded environment.

- **Empty File Filtering:** Added logic to detect and filter out data files with zero records, preventing them from improperly influencing the `txid` metadata calculations.

- **Single Partition Valid Through:** Added a partition check so on single partition topics the valid through no longer removes 1 keeping the data more up to date especially in low flowing topics improving test results and data lag as we are no longer unessesarily holding onto the last transaction.

**Testing**
This has been battle tested in an environment with the entire VM prod dataflow being pushed through one sink to push as many topic and partitions as possible through the app at as high of volume as possible.  