### PR TITLE
Missing txid metadata

### DIFF
--- a/kafka-connect-events/src/main/java/io/tabular/iceberg/connect/events/DataWrittenTxId.java
+++ b/kafka-connect-events/src/main/java/io/tabular/iceberg/connect/events/DataWrittenTxId.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.tabular.iceberg.connect.events;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.connect.events.PayloadType;
+import org.apache.iceberg.connect.events.TableReference;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.Types;
+
+import java.util.List;
+import java.util.UUID;
+
+public class DataWrittenTxId implements org.apache.iceberg.connect.events.Payload{
+    private Types.StructType partitionType;
+
+    private UUID commitId;
+    private TableReference tableReference;
+    private List<DataFile> dataFiles;
+    private List<DeleteFile> deleteFiles;
+    private TopicPartitionTransaction topicPartitionTransaction;
+    private Types.StructType icebergSchema;
+    private final Schema avroSchema;
+
+    static final int COMMIT_ID = 10_300;
+    static final int TABLE_REFERENCE = 10_301;
+    static final int DATA_FILES = 10_302;
+    static final int DATA_FILES_ELEMENT = 10_303;
+    static final int DELETE_FILES = 10_304;
+    static final int DELETE_FILES_ELEMENT = 10_305;
+    static final int TOPIC_PARTITION_TRANSACTION = 10_306;
+
+    public DataWrittenTxId(Schema avroSchema) {
+        this.avroSchema = avroSchema;
+    }
+
+    public DataWrittenTxId(
+            Types.StructType partitionType,
+            UUID commitId,
+            TableReference tableReference,
+            List<DataFile> dataFiles,
+            List<DeleteFile> deleteFiles,
+            TopicPartitionTransaction topicPartitionTransaction) {
+        Preconditions.checkNotNull(commitId, "Commit ID cannot be null");
+        Preconditions.checkNotNull(tableReference, "Table reference cannot be null");
+        this.partitionType = partitionType;
+        this.commitId = commitId;
+        this.tableReference = tableReference;
+        this.dataFiles = dataFiles;
+        this.deleteFiles = deleteFiles;
+        this.topicPartitionTransaction = topicPartitionTransaction;
+        this.avroSchema = AvroSchemaUtil.convert(writeSchema(), getClass().getName());
+    }
+
+
+    @Override
+    public PayloadType type() {
+        return PayloadType.DATA_WRITTEN;
+    }
+
+    public UUID commitId() {
+        return commitId;
+    }
+
+    public TableReference tableReference() {
+        return tableReference;
+    }
+
+    public List<DataFile> dataFiles() {
+        return dataFiles;
+    }
+
+    public List<DeleteFile> deleteFiles() {
+        return deleteFiles;
+    }
+
+    public TopicPartitionTransaction topicPartitionTransaction() {
+        return topicPartitionTransaction;
+    }
+
+    @Override
+    public Types.StructType writeSchema() {
+        if (icebergSchema == null) {
+            Types.StructType dataFileStruct = DataFile.getType(partitionType);
+
+            this.icebergSchema =
+                    Types.StructType.of(
+                            Types.NestedField.required(COMMIT_ID, "commit_id", Types.UUIDType.get()),
+                            Types.NestedField.required(
+                                    TABLE_REFERENCE, "table_reference", TableReference.ICEBERG_SCHEMA),
+                            Types.NestedField.optional(
+                                    DATA_FILES,
+                                    "data_files",
+                                    Types.ListType.ofRequired(DATA_FILES_ELEMENT, dataFileStruct)),
+                            Types.NestedField.optional(
+                                    DELETE_FILES,
+                                    "delete_files",
+                                    Types.ListType.ofRequired(DELETE_FILES_ELEMENT, dataFileStruct)),
+                            Types.NestedField.optional(
+                                    TOPIC_PARTITION_TRANSACTION,
+                                    "topic_partition_transaction", TopicPartitionTransaction.ICEBERG_SCHEMA)
+                            );
+        }
+
+        return icebergSchema;
+    }
+
+    @Override
+    public Schema getSchema() {
+        return avroSchema;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void put(int i, Object v) {
+        switch (positionToId(i, avroSchema)) {
+            case COMMIT_ID:
+                this.commitId = (UUID) v;
+                return;
+            case TABLE_REFERENCE:
+                this.tableReference = (TableReference) v;
+                return;
+            case DATA_FILES:
+                this.dataFiles = (List<DataFile>) v;
+                return;
+            case DELETE_FILES:
+                this.deleteFiles = (List<DeleteFile>) v;
+                return;
+            case TOPIC_PARTITION_TRANSACTION:
+                this.topicPartitionTransaction = convertToTopicPartitionTransaction((GenericData.Record) v);
+                return;
+            default:
+                // ignore the object, it must be from a newer version of the format
+        }
+    }
+
+    @Override
+    public Object get(int i) {
+        switch (positionToId(i, avroSchema)) {
+            case COMMIT_ID:
+                return commitId;
+            case TABLE_REFERENCE:
+                return tableReference;
+            case DATA_FILES:
+                return dataFiles;
+            case DELETE_FILES:
+                return deleteFiles;
+            case TOPIC_PARTITION_TRANSACTION:
+                return topicPartitionTransaction;
+            default:
+                throw new UnsupportedOperationException("Unknown field ordinal: " + i);
+        }
+    }
+
+    static int positionToId(int position, Schema avroSchema) {
+        List<Schema.Field> fields = avroSchema.getFields();
+        Preconditions.checkArgument(
+                position >= 0 && position < fields.size(), "Invalid field position: " + position);
+        Object val = fields.get(position).getObjectProp(AvroSchemaUtil.FIELD_ID_PROP);
+        return val == null ? -1 : (int) val;
+    }
+
+    public TopicPartitionTransaction convertToTopicPartitionTransaction(GenericData.Record record) {
+        if (record == null) {return null;}
+        String topic = record.get("topic").toString() ;
+        Integer partition = (Integer) record.get("partition");
+        Long transactionId = (Long) record.get("txId");
+        return new TopicPartitionTransaction(topic, partition, transactionId);
+    }
+}

--- a/kafka-connect-events/src/main/java/io/tabular/iceberg/connect/events/TableTopicPartitionTransaction.java
+++ b/kafka-connect-events/src/main/java/io/tabular/iceberg/connect/events/TableTopicPartitionTransaction.java
@@ -139,4 +139,18 @@ public class TableTopicPartitionTransaction implements org.apache.avro.generic.I
         Object val = fields.get(position).getObjectProp(AvroSchemaUtil.FIELD_ID_PROP);
         return val == null ? -1 : (int) val;
     }
+
+    @Override
+    public String toString() {
+        return "TableTopicPartitionTransaction{" +
+                "topic='" + topic + '\'' +
+                ", partition=" + partition +
+                ", catalogName='" + catalogName + '\'' +
+                ", namespace=" + namespace +
+                ", tableName='" + tableName + '\'' +
+                ", txId=" + txId +
+                '}';
+    }
+
+
 }

--- a/kafka-connect-events/src/main/java/io/tabular/iceberg/connect/events/TableTopicPartitionTransaction.java
+++ b/kafka-connect-events/src/main/java/io/tabular/iceberg/connect/events/TableTopicPartitionTransaction.java
@@ -31,7 +31,6 @@ public class TableTopicPartitionTransaction implements org.apache.avro.generic.I
 
     private String topic;
     private Integer partition;
-    private String catalogName;
     private List<String> namespace;
     private String tableName;
     private Long txId;
@@ -41,17 +40,15 @@ public class TableTopicPartitionTransaction implements org.apache.avro.generic.I
     static final int TOPIC = 10_800;
     static final int PARTITION = 10_801;
     static final int TX_ID = 10_802;
-    static final int CATALOG_NAME = 10_803;
-    static final int NAMESPACE = 10_804;
-    static final int TABLE_NAME = 10_805;
-    static final int NAMESPACE_ELEMENT = 10_806;
+    static final int NAMESPACE = 10_803;
+    static final int TABLE_NAME = 10_804;
+    static final int NAMESPACE_ELEMENT = 10_805;
 
     public static final Types.StructType ICEBERG_SCHEMA =
             Types.StructType.of(
                     Types.NestedField.required(TOPIC, "topic", Types.StringType.get()),
                     Types.NestedField.required(PARTITION, "partition", Types.IntegerType.get()),
                     Types.NestedField.optional(TX_ID, "txId", Types.LongType.get()),
-                    Types.NestedField.required(CATALOG_NAME, "catalog_name", Types.StringType.get()),
                     Types.NestedField.required(NAMESPACE, "namespace", Types.ListType.ofRequired(NAMESPACE_ELEMENT, Types.StringType.get())),
                     Types.NestedField.required(TABLE_NAME, "table_name", Types.StringType.get())
             );
@@ -62,10 +59,9 @@ public class TableTopicPartitionTransaction implements org.apache.avro.generic.I
         this.avroSchema = avroSchema;
     }
 
-    public TableTopicPartitionTransaction(String topic, int partition, String catalogName, TableIdentifier tableIdentifier, Long txId) {
+    public TableTopicPartitionTransaction(String topic, int partition, TableIdentifier tableIdentifier, Long txId) {
         this.topic = topic;
         this.partition = partition;
-        this.catalogName = catalogName;
         this.namespace = Lists.newArrayList(tableIdentifier.namespace().levels());
         this.tableName = tableIdentifier.name();
         this.txId = txId;
@@ -74,7 +70,6 @@ public class TableTopicPartitionTransaction implements org.apache.avro.generic.I
 
     public String topic() { return topic; }
     public Integer partition() { return partition; }
-    public String catalogName() { return catalogName; }
     public Long txId() { return txId; }
 
     public TableIdentifier tableIdentifier() {
@@ -100,9 +95,6 @@ public class TableTopicPartitionTransaction implements org.apache.avro.generic.I
             case TX_ID:
                 this.txId = (Long) v;
                 return;
-            case CATALOG_NAME:
-                this.catalogName = v == null ? null : v.toString();
-                return;
             case NAMESPACE:
                 if (v instanceof List) {
                     this.namespace = ((List<?>) v).stream()
@@ -124,7 +116,6 @@ public class TableTopicPartitionTransaction implements org.apache.avro.generic.I
             case TOPIC: return topic;
             case PARTITION: return partition;
             case TX_ID: return txId;
-            case CATALOG_NAME: return catalogName;
             case NAMESPACE: return namespace;
             case TABLE_NAME: return tableName;
             default:
@@ -139,18 +130,5 @@ public class TableTopicPartitionTransaction implements org.apache.avro.generic.I
         Object val = fields.get(position).getObjectProp(AvroSchemaUtil.FIELD_ID_PROP);
         return val == null ? -1 : (int) val;
     }
-
-    @Override
-    public String toString() {
-        return "TableTopicPartitionTransaction{" +
-                "topic='" + topic + '\'' +
-                ", partition=" + partition +
-                ", catalogName='" + catalogName + '\'' +
-                ", namespace=" + namespace +
-                ", tableName='" + tableName + '\'' +
-                ", txId=" + txId +
-                '}';
-    }
-
 
 }

--- a/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/IntegrationTxIdPartitionTest.java
+++ b/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/IntegrationTxIdPartitionTest.java
@@ -127,7 +127,7 @@ public class IntegrationTxIdPartitionTest extends IntegrationTestBase {
     }
 
     @Test
-    public void MultiTopicConnectorCorrectlySetsSnapshotMetadata() {
+    public void multiTopicConnectorCorrectlySetsSnapshotMetadata() {
         createTopic(testTopic, 1);
         catalog.createTable(tableIdentifier, TEST_SCHEMA);
         createTopic(secondTestTopic, 1);
@@ -148,8 +148,6 @@ public class IntegrationTxIdPartitionTest extends IntegrationTestBase {
 
         Snapshot snapshotSecondTable = awaitSnapshot(secondTableIdentifier);
 
-
-
         assertRecordCount(snapshotFirstTable, 3);
         assertSnapshotTxIdProps(snapshotFirstTable, 102, 102);
 
@@ -158,10 +156,8 @@ public class IntegrationTxIdPartitionTest extends IntegrationTestBase {
 
     }
 
-
-
     @Test
-    public void MultiTopicMultiPartitionConnectorCorrectlySetsSnapshotMetadata() {
+    public void multiTopicMultiPartitionConnectorCorrectlySetsSnapshotMetadata() {
         createTopic(testTopic, 2);
         catalog.createTable(tableIdentifier, TEST_SCHEMA);
         createTopic(secondTestTopic, 2);
@@ -184,8 +180,6 @@ public class IntegrationTxIdPartitionTest extends IntegrationTestBase {
         Snapshot snapshotFirstTable = awaitSnapshot(tableIdentifier);
 
         Snapshot snapshotSecondTable = awaitSnapshot(secondTableIdentifier);
-
-
 
         assertRecordCount(snapshotFirstTable, 5);
         assertSnapshotTxIdProps(snapshotFirstTable, 104, 101);

--- a/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/IntegrationTxIdPartitionTest.java
+++ b/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/IntegrationTxIdPartitionTest.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.tabular.iceberg.connect;
+
+import static io.tabular.iceberg.connect.TestEvent.TEST_SCHEMA;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.Date;
+import java.util.Map;
+import java.util.UUID;
+
+
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SupportsNamespaces;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class IntegrationTxIdPartitionTest extends IntegrationTestBase {
+
+    private static final String TEST_DB = "test";
+    private static final String TEST_TABLE_PREFIX = "foobar_";
+    private static final int TEST_TOPIC_PARTITIONS = 3;
+
+    private static final String TEST_TABLE1 = "foobar1";
+    private static final String TEST_TABLE2 = "foobar2";
+    private static final TableIdentifier TABLE_IDENTIFIER1 = TableIdentifier.of(TEST_DB, TEST_TABLE1);
+    private static final TableIdentifier TABLE_IDENTIFIER2 = TableIdentifier.of(TEST_DB, TEST_TABLE2);
+
+    private String tableName;
+    private TableIdentifier tableIdentifier;
+    private String secondTestTopic;
+    private String secondTestTable;
+    private TableIdentifier secondTableIdentifier;
+
+    @BeforeEach
+    public void beforeEach() {
+        // Each test will have a unique topic and table name to ensure isolation
+        this.testTopic = "test-topic-" + UUID.randomUUID();
+        this.tableName = TEST_TABLE_PREFIX + UUID.randomUUID().toString().replace("-", "_");
+        this.tableIdentifier = TableIdentifier.of(TEST_DB, tableName);
+
+        this.secondTestTopic = "second-test-topic-" + UUID.randomUUID().toString().replace("-", "_");
+        this.secondTestTable = TEST_TABLE_PREFIX + UUID.randomUUID().toString().replace("-", "_");
+        this.secondTableIdentifier = TableIdentifier.of(TEST_DB, secondTestTable);
+
+        // Namespace can be shared, so create it if it doesn't exist
+        if (!((SupportsNamespaces) catalog).namespaceExists(Namespace.of(TEST_DB))) {
+            ((SupportsNamespaces) catalog).createNamespace(Namespace.of(TEST_DB));
+        }
+    }
+
+    @AfterEach
+    public void afterEach() {
+        context.stopConnector(connectorName);
+        deleteTopic(testTopic);
+        catalog.dropTable(tableIdentifier);
+    }
+
+    private void startConnector(boolean useSchema, int tasksMax, String topics) {
+        KafkaConnectContainer.Config connectorConfig =
+                new KafkaConnectContainer.Config(connectorName)
+                        .config("topics", topics)
+                        .config("connector.class", IcebergSinkConnector.class.getName())
+                        .config("tasks.max", tasksMax)
+                        .config("consumer.override.auto.offset.reset", "earliest")
+                        .config("key.converter", "org.apache.kafka.connect.json.JsonConverter")
+                        .config("key.converter.schemas.enable", false)
+                        .config("value.converter", "org.apache.kafka.connect.json.JsonConverter")
+                        .config("value.converter.schemas.enable", useSchema)
+                        .config("iceberg.tables.dynamic-enabled", true)
+                        .config("iceberg.tables.route-field", "type")
+                        .config("iceberg.control.commit.interval-ms", 3000) // Longer commit interval
+                        .config("iceberg.control.commit.timeout-ms", Integer.MAX_VALUE)
+                        .config("iceberg.kafka.auto.offset.reset", "earliest");
+
+        context.connectorCatalogProperties().forEach(connectorConfig::config);
+        context.startConnector(connectorConfig);
+    }
+
+
+    private Snapshot awaitSnapshot(TableIdentifier tableIdentifiered) {
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(60))
+                .pollInterval(Duration.ofSeconds(2))
+                .untilAsserted(
+                        () -> {
+                            Table table = catalog.loadTable(tableIdentifiered);
+                            assertThat(table.snapshots()).hasSizeGreaterThanOrEqualTo(1);
+                        });
+        return catalog.loadTable(tableIdentifiered).currentSnapshot();
+    }
+
+    private void assertSnapshotTxIdProps(Snapshot snapshot, long expectedMax, long expectedValidThrough) {
+        assertThat(snapshot).isNotNull();
+        Map<String, String> summary = snapshot.summary();
+        assertThat(summary.get("txid-max")).isEqualTo(String.valueOf(expectedMax));
+        assertThat(summary.get("txid-valid-through"))
+                .isEqualTo(String.valueOf(expectedValidThrough));
+
+    }
+
+    private void assertRecordCount(Snapshot snapshot, int recordCount) {
+        assertThat(snapshot).isNotNull();
+        assertThat(snapshot.summary().get("total-records")).isEqualTo(String.valueOf(recordCount));
+    }
+
+    @Test
+    public void MultiTopicConnectorCorrectlySetsSnapshotMetadata() {
+        createTopic(testTopic, 1);
+        catalog.createTable(tableIdentifier, TEST_SCHEMA);
+        createTopic(secondTestTopic, 1);
+        catalog.createTable(secondTableIdentifier, TEST_SCHEMA);
+
+
+        startConnector(true, 2, testTopic+ "," + secondTestTopic);
+
+
+        send(testTopic, 0, new TestEvent(1, tableIdentifier.toString(), new Date(), "p0d1", null, 100L), true);
+        send(testTopic, 0, new TestEvent(2, tableIdentifier.toString(), new Date(), "p0d2", null, 101L), true);
+        send(testTopic, 0, new TestEvent(3, tableIdentifier.toString(), new Date(), "p0d3", null, 102L), true);
+        send(secondTestTopic, 0, new TestEvent(1, secondTableIdentifier.toString(), new Date(), "p0d1", null, 98L), true);
+        send(secondTestTopic, 0, new TestEvent(2, secondTableIdentifier.toString(), new Date(), "p0d2", null, 99L), true);
+        flush();
+
+        Snapshot snapshotFirstTable = awaitSnapshot(tableIdentifier);
+
+        Snapshot snapshotSecondTable = awaitSnapshot(secondTableIdentifier);
+
+
+
+        assertRecordCount(snapshotFirstTable, 3);
+        assertSnapshotTxIdProps(snapshotFirstTable, 102, 102);
+
+        assertRecordCount(snapshotSecondTable, 2);
+        assertSnapshotTxIdProps(snapshotSecondTable, 99, 99); // this currently fails with 102 and 101
+
+    }
+
+
+
+    @Test
+    public void MultiTopicMultiPartitionConnectorCorrectlySetsSnapshotMetadata() {
+        createTopic(testTopic, 2);
+        catalog.createTable(tableIdentifier, TEST_SCHEMA);
+        createTopic(secondTestTopic, 2);
+        catalog.createTable(secondTableIdentifier, TEST_SCHEMA);
+
+
+        startConnector(true, 4, testTopic+ "," + secondTestTopic);
+
+
+        send(testTopic, 0, new TestEvent(1, tableIdentifier.toString(), new Date(), "p0d1", null, 100L), true);
+        send(testTopic, 0, new TestEvent(2, tableIdentifier.toString(), new Date(), "p0d2", null, 101L), true);
+        send(testTopic, 0, new TestEvent(3, tableIdentifier.toString(), new Date(), "p0d3", null, 102L), true);
+        send(testTopic, 1, new TestEvent(4, tableIdentifier.toString(), new Date(), "p0d4", null, 103L), true);
+        send(testTopic, 1, new TestEvent(5, tableIdentifier.toString(), new Date(), "p0d5", null, 104L), true);
+        send(secondTestTopic, 0, new TestEvent(1, secondTableIdentifier.toString(), new Date(), "p0d1", null, 97L), true);
+        send(secondTestTopic, 0, new TestEvent(2, secondTableIdentifier.toString(), new Date(), "p0d2", null, 98L), true);
+        send(secondTestTopic, 1, new TestEvent(3, secondTableIdentifier.toString(), new Date(), "p0d3", null, 99L), true);
+        flush();
+
+        Snapshot snapshotFirstTable = awaitSnapshot(tableIdentifier);
+
+        Snapshot snapshotSecondTable = awaitSnapshot(secondTableIdentifier);
+
+
+
+        assertRecordCount(snapshotFirstTable, 5);
+        assertSnapshotTxIdProps(snapshotFirstTable, 104, 101);
+
+        assertRecordCount(snapshotSecondTable, 3);
+        assertSnapshotTxIdProps(snapshotSecondTable, 99, 97); // this currently fails with 102 and 101
+
+    }
+
+
+}

--- a/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/TestContext.java
+++ b/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/TestContext.java
@@ -59,6 +59,7 @@ public class TestContext {
   private final KafkaConnectContainer kafkaConnect;
   private final GenericContainer catalog;
   private final GenericContainer minio;
+  private final GenericContainer kafkaUi;
 
   private static final String LOCAL_INSTALL_DIR = "build/install";
   private static final String KC_PLUGIN_DIR = "/test/kafka-connect";
@@ -67,6 +68,9 @@ public class TestContext {
   private static final String KAFKA_IMAGE = "confluentinc/cp-kafka:7.5.1";
   private static final String CONNECT_IMAGE = "confluentinc/cp-kafka-connect:7.5.1";
   private static final String REST_CATALOG_IMAGE = "tabulario/iceberg-rest:0.6.0";
+
+  private static final String KAFKA_UI_IMAGE = "provectuslabs/kafka-ui:latest";
+  private static final int KAFKA_UI_PORT = 8080;
 
   private static final int MINIO_PORT = 9000;
   private static final int CATALOG_PORT = 8181;
@@ -110,7 +114,14 @@ public class TestContext {
             .withEnv("CONNECT_BOOTSTRAP_SERVERS", kafka.getNetworkAliases().get(0) + ":9092")
             .withEnv("CONNECT_OFFSET_FLUSH_INTERVAL_MS", "500");
 
-    Startables.deepStart(Stream.of(minio, catalog, kafka, kafkaConnect)).join();
+    kafkaUi = new GenericContainer<>(DockerImageName.parse(KAFKA_UI_IMAGE))
+            .withNetwork(network)
+            .dependsOn(kafka)
+            .withExposedPorts(KAFKA_UI_PORT)
+            .withEnv("KAFKA_CLUSTERS_0_NAME", "local")
+            .withEnv("KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS", kafka.getNetworkAliases().get(0) + ":9092");
+
+    Startables.deepStart(Stream.of(minio, catalog, kafka, kafkaConnect, kafkaUi)).join();
 
     try (S3Client s3 = initLocalS3Client()) {
       s3.createBucket(req -> req.bucket(BUCKET));
@@ -119,12 +130,17 @@ public class TestContext {
     Runtime.getRuntime().addShutdownHook(new Thread(this::shutdown));
   }
 
+  private int getLocalKafkaUiPort() {
+    return kafkaUi.getMappedPort(KAFKA_UI_PORT);
+  }
+
   private void shutdown() {
     kafkaConnect.close();
     kafka.close();
     catalog.close();
     minio.close();
     network.close();
+    kafkaUi.close();
   }
 
   private int getLocalMinioPort() {

--- a/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/TestEvent.java
+++ b/kafka-connect-runtime/src/test/java/io/tabular/iceberg/connect/TestEvent.java
@@ -40,21 +40,21 @@ import org.apache.kafka.connect.storage.ConverterType;
 public class TestEvent {
 
   public static final Schema TEST_SCHEMA =
-      new Schema(
-          ImmutableList.of(
-              Types.NestedField.required(1, "id", Types.LongType.get()),
-              Types.NestedField.required(2, "type", Types.StringType.get()),
-              Types.NestedField.required(3, "ts", Types.TimestampType.withZone()),
-              Types.NestedField.required(4, "payload", Types.StringType.get())),
-          ImmutableSet.of(1));
+          new Schema(
+                  ImmutableList.of(
+                          Types.NestedField.required(1, "id", Types.LongType.get()),
+                          Types.NestedField.required(2, "type", Types.StringType.get()),
+                          Types.NestedField.required(3, "ts", Types.TimestampType.withZone()),
+                          Types.NestedField.required(4, "payload", Types.StringType.get())),
+                  ImmutableSet.of(1));
 
   public static final Schema TEST_SCHEMA_NO_ID =
-      new Schema(
-          ImmutableList.of(
-              Types.NestedField.required(1, "id", Types.LongType.get()),
-              Types.NestedField.required(2, "type", Types.StringType.get()),
-              Types.NestedField.required(3, "ts", Types.TimestampType.withZone()),
-              Types.NestedField.required(4, "payload", Types.StringType.get())));
+          new Schema(
+                  ImmutableList.of(
+                          Types.NestedField.required(1, "id", Types.LongType.get()),
+                          Types.NestedField.required(2, "type", Types.StringType.get()),
+                          Types.NestedField.required(3, "ts", Types.TimestampType.withZone()),
+                          Types.NestedField.required(4, "payload", Types.StringType.get())));
 
   public static final org.apache.kafka.connect.data.Schema TEST_CONNECT_SCHEMA =
       SchemaBuilder.struct()
@@ -66,13 +66,13 @@ public class TestEvent {
           .field("txid", org.apache.kafka.connect.data.Schema.OPTIONAL_INT64_SCHEMA);
 
   public static final PartitionSpec TEST_SPEC =
-      PartitionSpec.builderFor(TEST_SCHEMA).day("ts").build();
+          PartitionSpec.builderFor(TEST_SCHEMA).day("ts").build();
 
   private static final JsonConverter JSON_CONVERTER = new JsonConverter();
 
   static {
     JSON_CONVERTER.configure(
-        ImmutableMap.of(ConverterConfig.TYPE_CONFIG, ConverterType.VALUE.getName()));
+            ImmutableMap.of(ConverterConfig.TYPE_CONFIG, ConverterType.VALUE.getName()));
   }
 
   private final long id;
@@ -126,22 +126,23 @@ public class TestEvent {
   protected String serialize(boolean useSchema) {
     try {
       Struct value =
-          new Struct(TEST_CONNECT_SCHEMA)
-              .put("id", id)
-              .put("type", type)
-              .put("ts", ts)
-              .put("payload", payload)
-              .put("op", op)
-              .put("txid", txid);
+
+              new Struct(TEST_CONNECT_SCHEMA)
+                      .put("id", id)
+                      .put("type", type)
+                      .put("ts", ts)
+                      .put("payload", payload)
+                      .put("op", op)
+                      .put("txid", txid);
 
       String convertMethod =
-          useSchema ? "convertToJsonWithEnvelope" : "convertToJsonWithoutEnvelope";
+              useSchema ? "convertToJsonWithEnvelope" : "convertToJsonWithoutEnvelope";
       JsonNode json =
-          DynMethods.builder(convertMethod)
-              .hiddenImpl(
-                  JsonConverter.class, org.apache.kafka.connect.data.Schema.class, Object.class)
-              .build(JSON_CONVERTER)
-              .invoke(TestEvent.TEST_CONNECT_SCHEMA, value);
+              DynMethods.builder(convertMethod)
+                      .hiddenImpl(
+                              JsonConverter.class, org.apache.kafka.connect.data.Schema.class, Object.class)
+                      .build(JSON_CONVERTER)
+                      .invoke(TestEvent.TEST_CONNECT_SCHEMA, value);
       return MAPPER.writeValueAsString(json);
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/CommitState.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/CommitState.java
@@ -30,9 +30,9 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.UUID;
 
+import io.tabular.iceberg.connect.events.DataWrittenTxId;
 import io.tabular.iceberg.connect.events.TransactionDataComplete;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.connect.events.DataWritten;
 import org.apache.iceberg.connect.events.TopicPartitionOffset;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,7 +58,7 @@ public class CommitState {
     if (!isCommitInProgress()) {
       LOG.debug(
           "Received data written with commit-id={} when no commit in progress, this can happen during recovery",
-          ((DataWritten) envelope.event().payload()).commitId());
+          ((DataWrittenTxId) envelope.event().payload()).commitId());
     }
   }
 
@@ -148,7 +148,7 @@ public class CommitState {
         .collect(
             groupingBy(
                 envelope ->
-                    ((DataWritten) envelope.event().payload())
+                    ((DataWrittenTxId) envelope.event().payload())
                         .tableReference()
                         .identifier()));
   }

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Committable.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Committable.java
@@ -20,7 +20,6 @@ package io.tabular.iceberg.connect.channel;
 
 import io.tabular.iceberg.connect.data.Offset;
 import io.tabular.iceberg.connect.data.WriterResult;
-import io.tabular.iceberg.connect.events.TableTopicPartitionTransaction;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -31,25 +30,17 @@ class Committable {
 
   private final ImmutableMap<TopicPartition, Offset> offsetsByTopicPartition;
 
-  private final ImmutableList<TableTopicPartitionTransaction> tableTxIds;
-
   private final ImmutableList<WriterResult> writerResults;
 
   Committable(
           Map<TopicPartition, Offset> offsetsByTopicPartition,
-          List<TableTopicPartitionTransaction> tableTxIds,
           List<WriterResult> writerResults) {
     this.offsetsByTopicPartition = ImmutableMap.copyOf(offsetsByTopicPartition);
-    this.tableTxIds = ImmutableList.copyOf(tableTxIds);
     this.writerResults = ImmutableList.copyOf(writerResults);
   }
 
   public Map<TopicPartition, Offset> offsetsByTopicPartition() {
     return offsetsByTopicPartition;
-  }
-
-  public List<TableTopicPartitionTransaction> getTableTxIds() {
-    return tableTxIds;
   }
 
   public List<WriterResult> writerResults() {

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/CommitterImpl.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/CommitterImpl.java
@@ -202,11 +202,9 @@ public class CommitterImpl extends Channel implements Committer, AutoCloseable {
     maybeCoordinatorThread.ifPresent(CoordinatorThread::terminate);
   }
 
-  private TopicPartitionTransaction getTopicPartitionTransaction(Map<TopicPartition, Long> partitionMaxTxid) {
+  private List<TopicPartitionTransaction> getTopicPartitionTransaction(Map<TopicPartition, Long> partitionMaxTxid) {
     return partitionMaxTxid.entrySet().stream()
-            .findFirst()
             .map(x -> new TopicPartitionTransaction(x.getKey().topic(), x.getKey().partition(), x.getValue()))
-            .orElse(null);
-
+            .collect(toList());
   }
 }

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/CommitterImpl.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/CommitterImpl.java
@@ -180,6 +180,8 @@ public class CommitterImpl extends Channel implements Committer, AutoCloseable {
     //  TableTopicPartitionTransactions now
     List<TableTopicPartitionTransaction> tableTxIds = committable.getTableTxIds();
 
+    LOG.info("For commit={} sending response with tableTxids={}", commitId, tableTxIds);
+
     Event commitReady =
         new Event(
             config.controlGroupId(),

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/CommitterImpl.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/CommitterImpl.java
@@ -23,7 +23,8 @@ import static java.util.stream.Collectors.toMap;
 
 import io.tabular.iceberg.connect.IcebergSinkConfig;
 import io.tabular.iceberg.connect.data.Offset;
-import io.tabular.iceberg.connect.events.TableTopicPartitionTransaction;
+import io.tabular.iceberg.connect.events.DataWrittenTxId;
+import io.tabular.iceberg.connect.events.TopicPartitionTransaction;
 import io.tabular.iceberg.connect.events.TransactionDataComplete;
 import java.io.IOException;
 import java.time.Duration;
@@ -33,7 +34,6 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import org.apache.iceberg.catalog.Catalog;
-import org.apache.iceberg.connect.events.DataWritten;
 import org.apache.iceberg.connect.events.Event;
 import org.apache.iceberg.connect.events.PayloadType;
 import org.apache.iceberg.connect.events.StartCommit;
@@ -106,7 +106,7 @@ public class CommitterImpl extends Channel implements Committer, AutoCloseable {
             receive(
                 envelope,
                 // CommittableSupplier that always returns empty committables
-                () -> new Committable(ImmutableMap.of(), ImmutableList.of(), ImmutableList.of())));
+                () -> new Committable(ImmutableMap.of(), ImmutableList.of())));
   }
 
   private Map<TopicPartition, Long> fetchStableConsumerOffsets(String groupId) {
@@ -150,12 +150,13 @@ public class CommitterImpl extends Channel implements Committer, AutoCloseable {
               Event commitResponse =
                   new Event(
                       config.controlGroupId(),
-                      new DataWritten(
+                      new DataWrittenTxId(
                           writerResult.partitionStruct(),
                           commitId,
                           TableReference.of(config.catalogName(), writerResult.tableIdentifier()),
                           writerResult.dataFiles(),
-                          writerResult.deleteFiles()));
+                          writerResult.deleteFiles(),
+                          getTopicPartitionTransaction(writerResult.partitionMaxTxids())));
 
               events.add(commitResponse);
             });
@@ -177,15 +178,11 @@ public class CommitterImpl extends Channel implements Committer, AutoCloseable {
                 })
             .collect(toList());
 
-    //  TableTopicPartitionTransactions now
-    List<TableTopicPartitionTransaction> tableTxIds = committable.getTableTxIds();
-
-    LOG.info("For commit={} sending response with tableTxids={}", commitId, tableTxIds);
 
     Event commitReady =
         new Event(
             config.controlGroupId(),
-            new TransactionDataComplete(commitId, assignments, tableTxIds));
+            new TransactionDataComplete(commitId, assignments));
     events.add(commitReady);
 
     Map<TopicPartition, Offset> offsets = committable.offsetsByTopicPartition();
@@ -203,5 +200,13 @@ public class CommitterImpl extends Channel implements Committer, AutoCloseable {
   public void close() throws IOException {
     stop();
     maybeCoordinatorThread.ifPresent(CoordinatorThread::terminate);
+  }
+
+  private TopicPartitionTransaction getTopicPartitionTransaction(Map<TopicPartition, Long> partitionMaxTxid) {
+    return partitionMaxTxid.entrySet().stream()
+            .findFirst()
+            .map(x -> new TopicPartitionTransaction(x.getKey().topic(), x.getKey().partition(), x.getValue()))
+            .orElse(null);
+
   }
 }

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Coordinator.java
@@ -51,6 +51,7 @@ import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.connect.events.CommitComplete;
 import org.apache.iceberg.connect.events.CommitToTable;
+import org.apache.iceberg.connect.events.DataWritten;
 import org.apache.iceberg.connect.events.Event;
 import org.apache.iceberg.connect.events.StartCommit;
 import org.apache.iceberg.connect.events.TableReference;
@@ -132,6 +133,8 @@ public class Coordinator extends Channel implements AutoCloseable {
   private boolean receive(Envelope envelope) {
     switch (envelope.event().type()) {
       case DATA_WRITTEN:
+        DataWritten writtenEvent = (DataWritten) envelope.event().payload();
+        LOG.info("Received data written event {}", writtenEvent.commitId());
         commitState.addResponse(envelope);
         return true;
       case DATA_COMPLETE:

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Coordinator.java
@@ -24,8 +24,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.tabular.iceberg.connect.IcebergSinkConfig;
 import io.tabular.iceberg.connect.data.Utilities;
-import io.tabular.iceberg.connect.events.TableTopicPartitionTransaction;
-import io.tabular.iceberg.connect.events.TransactionDataComplete;
+import io.tabular.iceberg.connect.events.DataWrittenTxId;
+import io.tabular.iceberg.connect.events.TopicPartitionTransaction;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.Duration;
@@ -35,7 +35,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 
@@ -51,7 +50,6 @@ import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.connect.events.CommitComplete;
 import org.apache.iceberg.connect.events.CommitToTable;
-import org.apache.iceberg.connect.events.DataWritten;
 import org.apache.iceberg.connect.events.Event;
 import org.apache.iceberg.connect.events.StartCommit;
 import org.apache.iceberg.connect.events.TableReference;
@@ -62,7 +60,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.Tasks;
 import org.apache.iceberg.util.ThreadPools;
 import org.apache.kafka.clients.admin.MemberDescription;
-import org.apache.kafka.common.TopicPartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,11 +80,8 @@ public class Coordinator extends Channel implements AutoCloseable {
   private final String snapshotOffsetsProp;
   private final ExecutorService exec;
   private final CommitState commitState;
-    /**
-     * Map of commit ID to a map of table identifiers to a map of topic partitions and their highest transaction IDs.
-     * This is used to track the transaction IDs for each table in the current commit.
-     */
-  private final Map<UUID, Map<TableIdentifier, Map<TopicPartition, Long>>> commitTxIdsByTable;
+
+  private final Map<TableIdentifier, List<TopicPartitionTransaction>> txIdsByTable;
 
   public Coordinator(
       Catalog catalog,
@@ -105,7 +99,7 @@ public class Coordinator extends Channel implements AutoCloseable {
         String.format(OFFSETS_SNAPSHOT_PROP_FMT, config.controlTopic(), config.controlGroupId());
     this.exec = ThreadPools.newWorkerPool("iceberg-committer", config.commitThreads());
     this.commitState = new CommitState(config);
-    this.commitTxIdsByTable = Maps.newConcurrentMap();
+    this.txIdsByTable = Maps.newHashMap();
 
     // initial poll with longer duration so the consumer will initialize...
     consumeAvailable(Duration.ofMillis(1000), this::receive);
@@ -133,28 +127,18 @@ public class Coordinator extends Channel implements AutoCloseable {
   private boolean receive(Envelope envelope) {
     switch (envelope.event().type()) {
       case DATA_WRITTEN:
-        DataWritten writtenEvent = (DataWritten) envelope.event().payload();
-        LOG.info("Received data written event {}", writtenEvent.commitId());
         commitState.addResponse(envelope);
+        if (envelope.event().payload() instanceof DataWrittenTxId) {
+          DataWrittenTxId payload = (DataWrittenTxId) envelope.event().payload();
+          if (payload.topicPartitionTransaction() != null) {
+            txIdsByTable.computeIfAbsent(payload.tableReference().identifier(),  k -> Lists.newArrayList());
+            txIdsByTable.get(payload.tableReference().identifier()).add(payload.topicPartitionTransaction());
+          }
+
+        }
         return true;
       case DATA_COMPLETE:
           commitState.addReady(envelope);
-          if (envelope.event().payload() instanceof TransactionDataComplete) {
-            TransactionDataComplete payload = (TransactionDataComplete) envelope.event().payload();
-            List<TableTopicPartitionTransaction> tableTxIds = payload.tableTxIds();
-            UUID commitId = payload.commitId();
-            LOG.info("Received transaction data complete event with {} txIds for commitId {} and here it is {}",
-                    tableTxIds.size(), commitId, tableTxIds);
-            Map<TableIdentifier, Map<TopicPartition, Long>> currentCommitTxIds =
-                    commitTxIdsByTable.computeIfAbsent(commitId, k -> Maps.newConcurrentMap());
-            tableTxIds.forEach(txId -> {
-              TableIdentifier tableIdentifier = txId.tableIdentifier();
-              TopicPartition tp = new TopicPartition(txId.topic(), txId.partition());
-              Map<TopicPartition, Long> tableTxMap = currentCommitTxIds.computeIfAbsent(
-                      tableIdentifier, k -> Maps.newConcurrentMap());
-              tableTxMap.merge(tp, txId.txId(), this::compareTxIds);
-            });
-          }
           if (commitState.isCommitReady(totalPartitionCount)) {
             commit(false);
           }
@@ -200,10 +184,6 @@ public class Coordinator extends Channel implements AutoCloseable {
     } catch (Exception e) {
       LOG.warn("Commit failed, will try again next cycle", e);
     } finally {
-      UUID commitId = commitState.currentCommitId();
-      if (commitId != null) {
-        commitTxIdsByTable.remove(commitId);
-      }
       commitState.endCurrentCommit();
     }
   }
@@ -225,6 +205,7 @@ public class Coordinator extends Channel implements AutoCloseable {
     // we should only get here if all tables committed successfully...
     commitConsumerOffsets();
     commitState.clearResponses();
+    txIdsByTable.clear();
 
     Event event =
         new Event(config.controlGroupId(), new CommitComplete(commitState.currentCommitId(), vtts));
@@ -288,11 +269,10 @@ public class Coordinator extends Channel implements AutoCloseable {
       LOG.info("Nothing to commit to table {}, skipping", tableIdentifier);
     } else {
       // Get transaction IDs for this specific commit and table
-      Map<TopicPartition, Long> tableHighestTxIds = getCommitTxIdsForTable(tableIdentifier);
+      List<TopicPartitionTransaction> tableHighestTxIds = getCommitTxIdsForTable(tableIdentifier);
 
       long txIdValidThrough = Utilities.calculateTxIdValidThrough(tableHighestTxIds);
       long maxTxId = Utilities.getMaxTxId(tableHighestTxIds);
-      LOG.info("Found txids for table {}: txIdValidThrough={}, maxTxId={}", tableIdentifier,  txIdValidThrough, maxTxId);
 
       if (deleteFiles.isEmpty()) {
         Transaction transaction = table.newTransaction();
@@ -364,21 +344,12 @@ public class Coordinator extends Channel implements AutoCloseable {
    * Get the transaction IDs for a specific table in the current commit.
    * This ensures we only use transaction data that belongs to the current commit.
    */
-  private Map<TopicPartition, Long> getCommitTxIdsForTable(TableIdentifier tableIdentifier) {
-    LOG.info("Getting commitTxIds for table {} in commit {}", tableIdentifier, commitState.currentCommitId());
-    if (commitState.currentCommitId() == null) {
-      return Collections.emptyMap();
+  private List<TopicPartitionTransaction> getCommitTxIdsForTable(TableIdentifier tableIdentifier) {
+    if (txIdsByTable.containsKey(tableIdentifier)) {
+      return txIdsByTable.get(tableIdentifier);
     }
-
-    Map<TableIdentifier, Map<TopicPartition, Long>> currentCommitTxIds =
-            commitTxIdsByTable.get(commitState.currentCommitId());
-
-    if (currentCommitTxIds == null) {
-      LOG.info("currentCommitTxIds is null for for table {} in commit {}",  tableIdentifier, commitState.currentCommitId());
-      return Collections.emptyMap();
-    }
-
-    return currentCommitTxIds.getOrDefault(tableIdentifier, Collections.emptyMap());
+    LOG.warn("No partition transactions found for table {} in commit {} ", tableIdentifier, commitState.currentCommitId());
+    return Collections.emptyList();
   }
 
   private void addTxDataToSnapshot(SnapshotUpdate<?> operation, long txIdValidThrough, long maxTxId) {
@@ -420,7 +391,7 @@ public class Coordinator extends Channel implements AutoCloseable {
   @Override
   public void close() throws IOException {
     exec.shutdownNow();
-    commitTxIdsByTable.clear();
+    txIdsByTable.clear();
     stop();
   }
 }

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Coordinator.java
@@ -140,7 +140,7 @@ public class Coordinator extends Channel implements AutoCloseable {
             TransactionDataComplete payload = (TransactionDataComplete) envelope.event().payload();
             List<TableTopicPartitionTransaction> tableTxIds = payload.tableTxIds();
             UUID commitId = payload.commitId();
-            LOG.debug("Received transaction data complete event with {} txIds for commitId {} and here it is {}",
+            LOG.info("Received transaction data complete event with {} txIds for commitId {} and here it is {}",
                     tableTxIds.size(), commitId, tableTxIds);
             Map<TableIdentifier, Map<TopicPartition, Long>> currentCommitTxIds =
                     commitTxIdsByTable.computeIfAbsent(commitId, k -> Maps.newConcurrentMap());
@@ -289,6 +289,7 @@ public class Coordinator extends Channel implements AutoCloseable {
 
       long txIdValidThrough = Utilities.calculateTxIdValidThrough(tableHighestTxIds);
       long maxTxId = Utilities.getMaxTxId(tableHighestTxIds);
+      LOG.info("Found txids for table {}: txIdValidThrough={}, maxTxId={}", tableIdentifier,  txIdValidThrough, maxTxId);
 
       if (deleteFiles.isEmpty()) {
         Transaction transaction = table.newTransaction();
@@ -361,6 +362,7 @@ public class Coordinator extends Channel implements AutoCloseable {
    * This ensures we only use transaction data that belongs to the current commit.
    */
   private Map<TopicPartition, Long> getCommitTxIdsForTable(TableIdentifier tableIdentifier) {
+    LOG.info("Getting commitTxIds for table {} in commit {}", tableIdentifier, commitState.currentCommitId());
     if (commitState.currentCommitId() == null) {
       return Collections.emptyMap();
     }
@@ -369,6 +371,7 @@ public class Coordinator extends Channel implements AutoCloseable {
             commitTxIdsByTable.get(commitState.currentCommitId());
 
     if (currentCommitTxIds == null) {
+      LOG.info("currentCommitTxIds is null for for table {} in commit {}",  tableIdentifier, commitState.currentCommitId());
       return Collections.emptyMap();
     }
 

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Coordinator.java
@@ -132,7 +132,7 @@ public class Coordinator extends Channel implements AutoCloseable {
           DataWrittenTxId payload = (DataWrittenTxId) envelope.event().payload();
           if (payload.topicPartitionTransaction() != null) {
             txIdsByTable.computeIfAbsent(payload.tableReference().identifier(),  k -> Lists.newArrayList());
-            txIdsByTable.get(payload.tableReference().identifier()).add(payload.topicPartitionTransaction());
+            txIdsByTable.get(payload.tableReference().identifier()).addAll(payload.topicPartitionTransaction());
           }
 
         }

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Deduplicated.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Deduplicated.java
@@ -28,10 +28,11 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import io.tabular.iceberg.connect.events.DataWrittenTxId;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.connect.events.DataWritten;
 import org.apache.iceberg.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,7 +84,7 @@ class Deduplicated {
         tableIdentifier,
         envelopes,
         "data",
-        DataWritten::dataFiles,
+        DataWrittenTxId::dataFiles,
         dataFile -> dataFile.path().toString());
   }
 
@@ -98,7 +99,7 @@ class Deduplicated {
         tableIdentifier,
         envelopes,
         "delete",
-        DataWritten::deleteFiles,
+            DataWrittenTxId::deleteFiles,
         deleteFile -> deleteFile.path().toString());
   }
 
@@ -107,13 +108,13 @@ class Deduplicated {
       TableIdentifier tableIdentifier,
       List<Envelope> envelopes,
       String fileType,
-      Function<DataWritten, List<F>> extractFilesFromPayload,
+      Function<DataWrittenTxId, List<F>> extractFilesFromPayload,
       Function<F, String> extractPathFromFile) {
     List<Pair<F, SimpleEnvelope>> filesAndEnvelopes =
         envelopes.stream()
             .flatMap(
                 envelope -> {
-                  DataWritten payload = (DataWritten) envelope.event().payload();
+                  DataWrittenTxId payload = (DataWrittenTxId) envelope.event().payload();
                   List<F> files = extractFilesFromPayload.apply(payload);
                   if (files == null) {
                     return Stream.empty();
@@ -216,7 +217,7 @@ class Deduplicated {
       eventId = envelope.event().id();
       eventGroupId = envelope.event().groupId();
       eventTimestamp = envelope.event().timestamp();
-      payloadCommitId = ((DataWritten) envelope.event().payload()).commitId();
+      payloadCommitId = ((DataWrittenTxId) envelope.event().payload()).commitId();
     }
 
     @Override

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/EventDecoder.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/EventDecoder.java
@@ -23,7 +23,6 @@ import io.tabular.iceberg.connect.events.CommitReadyPayload;
 import io.tabular.iceberg.connect.events.CommitRequestPayload;
 import io.tabular.iceberg.connect.events.CommitResponsePayload;
 import io.tabular.iceberg.connect.events.CommitTablePayload;
-import io.tabular.iceberg.connect.events.TableTopicPartitionTransaction;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -35,7 +34,6 @@ import org.apache.avro.SchemaParseException;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.avro.AvroSchemaUtil;
-import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.connect.events.AvroUtil;
 import org.apache.iceberg.connect.events.CommitComplete;
 import org.apache.iceberg.connect.events.CommitToTable;
@@ -113,17 +111,7 @@ public class EventDecoder {
                                   Instant.ofEpochMilli(t.timestamp()), ZoneOffset.UTC)))
               .collect(Collectors.toList());
 
-      List<TableTopicPartitionTransaction> convertedTxIds =
-              pay.txIds().stream()
-                      .map(txId -> new TableTopicPartitionTransaction(
-                              txId.topic(),
-                              txId.partition(),
-                              catalogName,  // Use the catalogName from the decoder
-                              TableIdentifier.of("default"),  // Provide default or extract from payload
-                              txId.txId()))
-                      .collect(Collectors.toList());
-
-      return new TransactionDataComplete(pay.commitId(), converted, convertedTxIds);
+      return new TransactionDataComplete(pay.commitId(), converted);
     } else if (payload instanceof CommitTablePayload) {
       CommitTablePayload pay = (CommitTablePayload) payload;
       return new CommitToTable(

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Worker.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Worker.java
@@ -66,7 +66,7 @@ class Worker implements Writer, AutoCloseable, CommittableSupplier {
   }
 
   @Override
-  public synchronized Committable committable() {
+  public Committable committable() {
     LOG.info("Committing committable");
     List<WriterResult> writerResults =
             writers.values().stream()
@@ -113,20 +113,20 @@ class Worker implements Writer, AutoCloseable, CommittableSupplier {
   }
 
   @Override
-  public synchronized void close() throws IOException {
+  public void close() throws IOException {
     writers.values().forEach(RecordWriter::close);
     writers.clear();
     sourceOffsets.clear();
   }
 
   @Override
-  public synchronized void write(Collection<SinkRecord> sinkRecords) {
+  public void write(Collection<SinkRecord> sinkRecords) {
     if (sinkRecords != null && !sinkRecords.isEmpty()) {
       sinkRecords.forEach(this::save);
     }
   }
 
-  private synchronized void save(SinkRecord record) {
+  private void save(SinkRecord record) {
     // the consumer stores the offsets that corresponds to the next record to consume,
     // so increment the record offset by one
     sourceOffsets.put(

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Worker.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Worker.java
@@ -26,19 +26,14 @@ import io.tabular.iceberg.connect.data.Offset;
 import io.tabular.iceberg.connect.data.RecordWriter;
 import io.tabular.iceberg.connect.data.Utilities;
 import io.tabular.iceberg.connect.data.WriterResult;
-import io.tabular.iceberg.connect.events.TableTopicPartitionTransaction;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.iceberg.DataFile;
-import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.catalog.Catalog;
-import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -67,44 +62,13 @@ class Worker implements Writer, AutoCloseable, CommittableSupplier {
 
   @Override
   public Committable committable() {
-    LOG.info("Committing committable");
     List<WriterResult> writerResults =
             writers.values().stream()
                     .flatMap(writer -> writer.complete().stream())
                     .collect(toList());
 
-    writerResults.forEach(res -> {
-      long totalRecords = res.dataFiles().stream().mapToLong(DataFile::recordCount).sum() +
-              res.deleteFiles().stream().mapToLong(DeleteFile::recordCount).sum();
-
-      LOG.info("WriterResult for table {}: Total records = {}, TxID map = {}",
-              res.tableIdentifier(), totalRecords, res.partitionMaxTxids());
-    });
-
-    Map<TableIdentifier, Map<TopicPartition, Long>> aggregatedTxIds = Maps.newHashMap();
-    writerResults.forEach(res -> {
-      if (res.partitionMaxTxids() != null && !res.partitionMaxTxids().isEmpty()) {
-        Map<TopicPartition, Long> tableTxIds =
-                aggregatedTxIds.computeIfAbsent(res.tableIdentifier(), k -> Maps.newHashMap());
-        res.partitionMaxTxids()
-                .forEach((tp, txid) -> tableTxIds.merge(tp, txid, Long::max));
-      }
-    });
-
-    List<TableTopicPartitionTransaction> finalTableTxIds = Lists.newArrayList();
-    aggregatedTxIds.forEach((tableIdentifier, partitionTxIds) -> {
-      String catalogName = config.catalogName();
-      partitionTxIds.forEach((tp, txId) ->
-              finalTableTxIds.add(
-                      new TableTopicPartitionTransaction(
-                              tp.topic(), tp.partition(), catalogName, tableIdentifier, txId)));
-    });
-
-    LOG.info("For worker committable ready. Found {} transaction IDs from {} writer results. TableTxids: {}",
-            finalTableTxIds.size(), writerResults.size(), finalTableTxIds);
-
     Map<TopicPartition, Offset> offsets = Maps.newHashMap(sourceOffsets);
-    Committable result = new Committable(offsets, finalTableTxIds, writerResults);
+    Committable result = new Committable(offsets, writerResults);
 
     writers.clear();
     sourceOffsets.clear();

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Worker.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Worker.java
@@ -67,6 +67,7 @@ class Worker implements Writer, AutoCloseable, CommittableSupplier {
 
   @Override
   public synchronized Committable committable() {
+    LOG.info("Committing committable");
     List<WriterResult> writerResults =
             writers.values().stream()
                     .flatMap(writer -> writer.complete().stream())
@@ -76,7 +77,7 @@ class Worker implements Writer, AutoCloseable, CommittableSupplier {
       long totalRecords = res.dataFiles().stream().mapToLong(DataFile::recordCount).sum() +
               res.deleteFiles().stream().mapToLong(DeleteFile::recordCount).sum();
 
-      LOG.debug("WriterResult for table {}: Total records = {}, TxID map = {}",
+      LOG.info("WriterResult for table {}: Total records = {}, TxID map = {}",
               res.tableIdentifier(), totalRecords, res.partitionMaxTxids());
     });
 
@@ -99,8 +100,8 @@ class Worker implements Writer, AutoCloseable, CommittableSupplier {
                               tp.topic(), tp.partition(), catalogName, tableIdentifier, txId)));
     });
 
-    LOG.info("Committable ready. Found {} transaction IDs from {} writer results.",
-            finalTableTxIds.size(), writerResults.size());
+    LOG.info("For worker committable ready. Found {} transaction IDs from {} writer results. TableTxids: {}",
+            finalTableTxIds.size(), writerResults.size(), finalTableTxIds);
 
     Map<TopicPartition, Offset> offsets = Maps.newHashMap(sourceOffsets);
     Committable result = new Committable(offsets, finalTableTxIds, writerResults);

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/IcebergWriter.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/IcebergWriter.java
@@ -75,7 +75,6 @@ public class IcebergWriter implements RecordWriter {
       if (record.value() != null) {
         Long txId = Utilities.extractTxIdFromRecordValue(record.value(), COL_TXID);
         if (txId != null) {
-          LOG.info("Found txid {} for table {} and partition {}", txId, tableName, record.kafkaPartition());
           TopicPartition tp = new TopicPartition(record.topic(), record.kafkaPartition());
           partitionMaxTxids.merge(tp, txId, Long::max);
         }
@@ -162,7 +161,6 @@ public class IcebergWriter implements RecordWriter {
     if (writeResult.deleteFiles() != null) {
       totalRecordCount += Arrays.stream(writeResult.deleteFiles()).mapToLong(DeleteFile::recordCount).sum();
     }
-    LOG.info("Writer for {} had Total record count: {}", tableName, totalRecordCount);
     if (totalRecordCount > 0) {
       writerResults.add(
               new WriterResult(
@@ -174,7 +172,6 @@ public class IcebergWriter implements RecordWriter {
     } else if (!partitionMaxTxids.isEmpty()) {
       LOG.debug(" Discarding {} txid entries for a batch that produced no records", partitionMaxTxids.size());
     }
-    LOG.info("Clearing down writer txids for {}, txId map {}", tableName, partitionMaxTxids);
     partitionMaxTxids.clear();
   }
 

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/Utilities.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/Utilities.java
@@ -312,11 +312,11 @@ public class Utilities {
 
   public static Long calculateTxIdValidThrough(Map<?, Long> highestTxIdPerPartition) {
     if (highestTxIdPerPartition.isEmpty()) {
-      LOG.debug("Transaction Map is empty, returning 0");
+      LOG.info("Transaction Map is empty, returning 0");
       return 0L;
     }
 
-    LOG.debug("Transaction Map contains {} entries", highestTxIdPerPartition.size());
+    LOG.info("Transaction Map contains {} entries", highestTxIdPerPartition.size());
     // Find the minimum value in the map, as it represents the highest transaction ID
     // that is common across all partitions
     long minValue = Collections.min(highestTxIdPerPartition.values());

--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/Utilities.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/data/Utilities.java
@@ -31,11 +31,12 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+
+import io.tabular.iceberg.connect.events.TopicPartitionTransaction;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Table;
@@ -310,27 +311,27 @@ public class Utilities {
     }
   }
 
-  public static Long calculateTxIdValidThrough(Map<?, Long> highestTxIdPerPartition) {
-    if (highestTxIdPerPartition.isEmpty()) {
-      LOG.info("Transaction Map is empty, returning 0");
+  public static Long calculateTxIdValidThrough(List<TopicPartitionTransaction> topicPartitionTransactions) {
+    if (topicPartitionTransactions.isEmpty()) {
+      LOG.warn("No transaction data to calculate txIdValidThrough");
       return 0L;
     }
 
-    LOG.info("Transaction Map contains {} entries", highestTxIdPerPartition.size());
-    // Find the minimum value in the map, as it represents the highest transaction ID
+    // Find the minimum value in the lost, as it represents the highest transaction ID
     // that is common across all partitions
-    long minValue = Collections.min(highestTxIdPerPartition.values());
+    long minValue = topicPartitionTransactions.stream().mapToLong(TopicPartitionTransaction::txId).min().orElse(0L);
 
     // If only one partition, return minValue directly.
-    // Subtract 1 from the minimum value to get the last guaranteed completed transaction ID
-    if (highestTxIdPerPartition.size() == 1) {
+    if (topicPartitionTransactions.size() == 1) {
       return minValue;
     }
+
+    // Subtract 1 from the minimum value to get the last guaranteed completed transaction ID
     return minValue > 1 ? minValue - 1 : 0;
   }
 
-  public static Long getMaxTxId(Map<?, Long> highestTxIdPerPartition) {
-    return highestTxIdPerPartition.values().stream().max(Long::compareTo).orElse(0L);
+  public static Long getMaxTxId(List<TopicPartitionTransaction> topicPartitionTransactions) {
+    return topicPartitionTransactions.stream().mapToLong(TopicPartitionTransaction::txId).max().orElse(0L);
   }
 
   private Utilities() {}

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CommitStateTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CommitStateTest.java
@@ -53,17 +53,17 @@ public class CommitStateTest {
     TransactionDataComplete payload1 = mock(TransactionDataComplete.class);
     when(payload1.commitId()).thenReturn(commitState.currentCommitId());
     when(payload1.assignments()).thenReturn(ImmutableList.of(tp, tp));
-    when(payload1.tableTxIds()).thenReturn(ImmutableList.of(tpt, tpt));
+
 
     TransactionDataComplete payload2 = mock(TransactionDataComplete.class);
     when(payload2.commitId()).thenReturn(commitState.currentCommitId());
     when(payload2.assignments()).thenReturn(ImmutableList.of(tp));
-    when(payload2.tableTxIds()).thenReturn(ImmutableList.of(tpt));
+
 
     TransactionDataComplete payload3 = mock(TransactionDataComplete.class);
     when(payload3.commitId()).thenReturn(UUID.randomUUID());
     when(payload3.assignments()).thenReturn(ImmutableList.of(tp));
-    when(payload3.tableTxIds()).thenReturn(ImmutableList.of(tpt));
+
 
     commitState.addReady(wrapInEnvelope(payload1));
     commitState.addReady(wrapInEnvelope(payload2));

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CoordinatorTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CoordinatorTest.java
@@ -22,9 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import io.tabular.iceberg.connect.events.DataWrittenTxId;
-import io.tabular.iceberg.connect.events.TableTopicPartitionTransaction;
 import io.tabular.iceberg.connect.events.TopicPartitionTransaction;
-import io.tabular.iceberg.connect.events.TopicPartitionTxId;
 import io.tabular.iceberg.connect.events.TransactionDataComplete;
 import io.tabular.iceberg.connect.fixtures.EventTestUtil;
 import java.time.Instant;
@@ -49,7 +47,6 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.connect.events.AvroUtil;
 import org.apache.iceberg.connect.events.CommitComplete;
 import org.apache.iceberg.connect.events.CommitToTable;
-import org.apache.iceberg.connect.events.DataWritten;
 import org.apache.iceberg.connect.events.Event;
 import org.apache.iceberg.connect.events.PayloadType;
 import org.apache.iceberg.connect.events.StartCommit;

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CoordinatorTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/CoordinatorTest.java
@@ -529,8 +529,6 @@ public class CoordinatorTest extends ChannelTestBase {
             });
   }
 
-
-
   private UUID coordinatorTest(Function<UUID, List<Event>> eventsFn) {
     when(config.commitIntervalMs()).thenReturn(0);
     when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/DeduplicatedTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/DeduplicatedTest.java
@@ -23,6 +23,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+
+import io.tabular.iceberg.connect.events.DataWrittenTxId;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
@@ -31,7 +33,6 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileMetadata;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.connect.events.DataWritten;
 import org.apache.iceberg.connect.events.Event;
 import org.apache.iceberg.connect.events.TableReference;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -123,8 +124,8 @@ class DeduplicatedTest {
   private Event commitResponseEvent(List<DataFile> dataFiles, List<DeleteFile> deleteFiles) {
     return new Event(
         GROUP_ID,
-        new DataWritten(
-            Types.StructType.of(), PAYLOAD_COMMIT_ID, TABLE_NAME, dataFiles, deleteFiles));
+        new DataWrittenTxId(
+            Types.StructType.of(), PAYLOAD_COMMIT_ID, TABLE_NAME, dataFiles, deleteFiles, null));
   }
 
   private <F> String detectedDuplicateFileAcrossMultipleEvents(

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/EventDecoderTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/EventDecoderTest.java
@@ -38,6 +38,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
+import io.tabular.iceberg.connect.events.TopicPartitionTransaction;
 import io.tabular.iceberg.connect.events.TopicPartitionTxId;
 import io.tabular.iceberg.connect.events.TransactionDataComplete;
 import org.apache.avro.Schema;
@@ -219,15 +220,6 @@ public class EventDecoderTest {
     assertThat(payload.assignments().get(1).offset()).isNull();
     assertThat(payload.assignments().get(1).timestamp()).isNull();
 
-    assertThat(payload.tableTxIds()).isNotEmpty();
-    assertThat(payload.tableTxIds().size()).isEqualTo(2);
-    assertThat(payload.tableTxIds().get(0).topic()).isEqualTo("topic");
-    assertThat(payload.tableTxIds().get(0).partition()).isEqualTo(1);
-    assertThat(payload.tableTxIds().get(0).txId()).isEqualTo(1L);
-
-    assertThat(payload.tableTxIds().get(1).topic()).isEqualTo("topic");
-    assertThat(payload.tableTxIds().get(1).partition()).isEqualTo(2);
-    assertThat(payload.tableTxIds().get(1).txId()).isNull();
   }
 
   @Test

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/EventDecoderTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/EventDecoderTest.java
@@ -38,7 +38,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
-import io.tabular.iceberg.connect.events.TopicPartitionTransaction;
 import io.tabular.iceberg.connect.events.TopicPartitionTxId;
 import io.tabular.iceberg.connect.events.TransactionDataComplete;
 import org.apache.avro.Schema;

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/WorkerTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/channel/WorkerTest.java
@@ -30,11 +30,9 @@ import io.tabular.iceberg.connect.data.IcebergWriterFactory;
 import io.tabular.iceberg.connect.data.WriterResult;
 import io.tabular.iceberg.connect.events.EventTestUtil;
 
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import io.tabular.iceberg.connect.events.TableTopicPartitionTransaction;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -76,9 +74,6 @@ public class WorkerTest {
     when(config.catalogName()).thenReturn("catalog");
     Map<String, Object> value = ImmutableMap.of(TRANSACTION_FIELD_NAME, 743);
     Committable committable = workerTest(config, value);
-    List<TableTopicPartitionTransaction> tableTxIds = committable.getTableTxIds();
-    assertThat(tableTxIds).isNotEmpty();
-    assertThat(tableTxIds.get(0).txId()).isEqualTo(743L);
   }
 
   private Committable workerTest(IcebergSinkConfig config, Map<String, Object> value) {

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/UtilitiesTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/UtilitiesTest.java
@@ -31,8 +31,6 @@ import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.hadoop.Configurable;
 import org.apache.iceberg.inmemory.InMemoryCatalog;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
-import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;

--- a/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/UtilitiesTest.java
+++ b/kafka-connect/src/test/java/io/tabular/iceberg/connect/data/UtilitiesTest.java
@@ -31,6 +31,8 @@ import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.hadoop.Configurable;
 import org.apache.iceberg.inmemory.InMemoryCatalog;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;


### PR DESCRIPTION
This changes the coordinator commitTxIdsByTable from a nested commit map to a single table identifier to list of topic txid map.
This new map is populated when the coordinator receives a datawritten message instead of the complete message and cleared directly after the commitbuffer to ensure there is a corresponding transaction data for every file that is to be written.