### PR TITLE
USD-4123/Enhance Sink Logging

### DIFF
--- a/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/src/main/java/io/tabular/iceberg/connect/channel/Coordinator.java
@@ -85,19 +85,19 @@ public class Coordinator extends Channel implements AutoCloseable {
   private final Map<TableIdentifier, List<TopicPartitionTransaction>> txIdsByTable;
 
   public Coordinator(
-      Catalog catalog,
-      IcebergSinkConfig config,
-      Collection<MemberDescription> members,
-      KafkaClientFactory clientFactory) {
+          Catalog catalog,
+          IcebergSinkConfig config,
+          Collection<MemberDescription> members,
+          KafkaClientFactory clientFactory) {
     // pass consumer group ID to which we commit low watermark offsets
     super("coordinator", config.controlGroupId() + "-coord", config, clientFactory);
 
     this.catalog = catalog;
     this.config = config;
     this.totalPartitionCount =
-        members.stream().mapToInt(desc -> desc.assignment().topicPartitions().size()).sum();
+            members.stream().mapToInt(desc -> desc.assignment().topicPartitions().size()).sum();
     this.snapshotOffsetsProp =
-        String.format(OFFSETS_SNAPSHOT_PROP_FMT, config.controlTopic(), config.controlGroupId());
+            String.format(OFFSETS_SNAPSHOT_PROP_FMT, config.controlTopic(), config.controlGroupId());
     this.exec = ThreadPools.newWorkerPool("iceberg-committer", config.commitThreads());
     this.commitState = new CommitState(config);
     this.txIdsByTable = Maps.newHashMap();
@@ -112,7 +112,7 @@ public class Coordinator extends Channel implements AutoCloseable {
       commitState.startNewCommit();
       LOG.info("Started new commit with commit-id={}", commitState.currentCommitId().toString());
       Event event =
-          new Event(config.controlGroupId(), new StartCommit(commitState.currentCommitId()));
+              new Event(config.controlGroupId(), new StartCommit(commitState.currentCommitId()));
       send(event);
       LOG.info("Sent workers commit trigger with commit-id={}", commitState.currentCommitId().toString());
 
@@ -139,10 +139,10 @@ public class Coordinator extends Channel implements AutoCloseable {
         }
         return true;
       case DATA_COMPLETE:
-          commitState.addReady(envelope);
-          if (commitState.isCommitReady(totalPartitionCount)) {
-            commit(false);
-          }
+        commitState.addReady(envelope);
+        if (commitState.isCommitReady(totalPartitionCount)) {
+          commit(false);
+        }
         return true;
     }
     return false;
@@ -196,12 +196,12 @@ public class Coordinator extends Channel implements AutoCloseable {
     OffsetDateTime vtts = commitState.vtts(partialCommit);
 
     Tasks.foreach(commitMap.entrySet())
-        .executeWith(exec)
-        .stopOnFailure()
-        .run(
-            entry -> {
-              commitToTable(entry.getKey(), entry.getValue(), offsetsJson, vtts, partialCommit);
-            });
+            .executeWith(exec)
+            .stopOnFailure()
+            .run(
+                    entry -> {
+                      commitToTable(entry.getKey(), entry.getValue(), offsetsJson, vtts, partialCommit);
+                    });
 
     // we should only get here if all tables committed successfully...
     commitConsumerOffsets();
@@ -209,14 +209,14 @@ public class Coordinator extends Channel implements AutoCloseable {
     txIdsByTable.clear();
 
     Event event =
-        new Event(config.controlGroupId(), new CommitComplete(commitState.currentCommitId(), vtts));
+            new Event(config.controlGroupId(), new CommitComplete(commitState.currentCommitId(), vtts));
     send(event);
 
     LOG.info(
-        "Commit {} complete, committed to {} table(s), vtts {}",
-        commitState.currentCommitId(),
-        commitMap.size(),
-        vtts);
+            "Commit {} complete, committed to {} table(s), vtts {}",
+            commitState.currentCommitId(),
+            commitMap.size(),
+            vtts);
   }
 
   private String offsetsJson() {
@@ -228,11 +228,11 @@ public class Coordinator extends Channel implements AutoCloseable {
   }
 
   private void commitToTable(
-      TableIdentifier tableIdentifier,
-      List<Envelope> envelopeList,
-      String offsetsJson,
-      OffsetDateTime vtts,
-      Boolean partialCommit) {
+          TableIdentifier tableIdentifier,
+          List<Envelope> envelopeList,
+          String offsetsJson,
+          OffsetDateTime vtts,
+          Boolean partialCommit) {
     Table table;
     try {
       table = catalog.loadTable(tableIdentifier);
@@ -246,127 +246,121 @@ public class Coordinator extends Channel implements AutoCloseable {
     Map<Integer, Long> committedOffsets = lastCommittedOffsetsForTable(table, branch.orElse(null));
 
     List<Envelope> filteredEnvelopeList =
-        envelopeList.stream()
-            .filter(
-                envelope -> {
-                  Long minOffset = committedOffsets.get(envelope.partition());
-                  return minOffset == null || envelope.offset() >= minOffset;
-                })
-            .collect(toList());
+            envelopeList.stream()
+                    .filter(
+                            envelope -> {
+                              Long minOffset = committedOffsets.get(envelope.partition());
+                              return minOffset == null || envelope.offset() >= minOffset;
+                            })
+                    .collect(toList());
 
     List<DataFile> dataFiles =
-        Deduplicated.dataFiles(commitState.currentCommitId(), tableIdentifier, filteredEnvelopeList)
-            .stream()
-            .filter(dataFile -> dataFile.recordCount() > 0)
-            .collect(toList());
+            Deduplicated.dataFiles(commitState.currentCommitId(), tableIdentifier, filteredEnvelopeList)
+                    .stream()
+                    .filter(dataFile -> dataFile.recordCount() > 0)
+                    .collect(toList());
 
     List<DeleteFile> deleteFiles =
-        Deduplicated.deleteFiles(
-                commitState.currentCommitId(), tableIdentifier, filteredEnvelopeList)
-            .stream()
-            .filter(deleteFile -> deleteFile.recordCount() > 0)
-            .collect(toList());
+            Deduplicated.deleteFiles(
+                            commitState.currentCommitId(), tableIdentifier, filteredEnvelopeList)
+                    .stream()
+                    .filter(deleteFile -> deleteFile.recordCount() > 0)
+                    .collect(toList());
 
     if (dataFiles.isEmpty() && deleteFiles.isEmpty()) {
       LOG.info("Nothing to commit to table {}, skipping", tableIdentifier);
-      return;
-    }
-
-    try {
-      // Get transaction IDs for this specific commit and table
-      List<TopicPartitionTransaction> tableHighestTxIds = getCommitTxIdsForTable(tableIdentifier);
-
-      long txIdValidThrough = Utilities.calculateTxIdValidThrough(tableHighestTxIds);
-      long maxTxId = Utilities.getMaxTxId(tableHighestTxIds);
-
-      Snapshot currentSnapshot = latestSnapshot(table, branch.orElse(null));
-      if (currentSnapshot == null) {
+    } else {
+      try {
         LOG.info(
-                "Attempting to commit to table {}, no previous snapshot found",
-                tableIdentifier);
-      } else {
-        LOG.info(
-                "Attempting to commit to table {}, current snapshot ID: {}",
+                "Starting commit for table {}, commit ID {}, with {} data files and {} delete files",
                 tableIdentifier,
-                currentSnapshot.snapshotId());
-      }
+                commitState.currentCommitId(),
+                dataFiles.size(),
+                deleteFiles.size());
 
-      if (deleteFiles.isEmpty()) {
-        Transaction transaction = table.newTransaction();
+        // Get transaction IDs for this specific commit and table
+        List<TopicPartitionTransaction> tableHighestTxIds = getCommitTxIdsForTable(tableIdentifier);
 
-        Map<Integer, List<DataFile>> filesBySpec =
-            dataFiles.stream()
-                .collect(Collectors.groupingBy(DataFile::specId, Collectors.toList()));
+        long txIdValidThrough = Utilities.calculateTxIdValidThrough(tableHighestTxIds);
+        long maxTxId = Utilities.getMaxTxId(tableHighestTxIds);
 
-        List<List<DataFile>> list = Lists.newArrayList(filesBySpec.values());
-        int lastIdx = list.size() - 1;
-        for (int i = 0; i <= lastIdx; i++) {
-          AppendFiles appendOp = transaction.newAppend();
-          branch.ifPresent(appendOp::toBranch);
+        if (deleteFiles.isEmpty()) {
+          Transaction transaction = table.newTransaction();
 
-          list.get(i).forEach(appendOp::appendFile);
-          appendOp.set(COMMIT_ID_SNAPSHOT_PROP, commitState.currentCommitId().toString());
-          if (i == lastIdx) {
-            appendOp.set(snapshotOffsetsProp, offsetsJson);
-            if (vtts != null) {
-              appendOp.set(VTTS_SNAPSHOT_PROP, Long.toString(vtts.toInstant().toEpochMilli()));
+          Map<Integer, List<DataFile>> filesBySpec =
+                  dataFiles.stream()
+                          .collect(Collectors.groupingBy(DataFile::specId, Collectors.toList()));
+
+          List<List<DataFile>> list = Lists.newArrayList(filesBySpec.values());
+          int lastIdx = list.size() - 1;
+          for (int i = 0; i <= lastIdx; i++) {
+            AppendFiles appendOp = transaction.newAppend();
+            branch.ifPresent(appendOp::toBranch);
+
+            list.get(i).forEach(appendOp::appendFile);
+            appendOp.set(COMMIT_ID_SNAPSHOT_PROP, commitState.currentCommitId().toString());
+            if (i == lastIdx) {
+              appendOp.set(snapshotOffsetsProp, offsetsJson);
+              if (vtts != null) {
+                appendOp.set(VTTS_SNAPSHOT_PROP, Long.toString(vtts.toInstant().toEpochMilli()));
+              }
+              addTxDataToSnapshot(appendOp, txIdValidThrough, maxTxId);
+              addCommitType(appendOp, partialCommit);
             }
-            addTxDataToSnapshot(appendOp, txIdValidThrough, maxTxId);
-            addCommitType(appendOp, partialCommit);
+
+            appendOp.commit();
           }
 
-          appendOp.commit();
+          transaction.commitTransaction();
+        } else {
+          RowDelta deltaOp = table.newRowDelta();
+          branch.ifPresent(deltaOp::toBranch);
+          deltaOp.set(snapshotOffsetsProp, offsetsJson);
+          deltaOp.set(COMMIT_ID_SNAPSHOT_PROP, commitState.currentCommitId().toString());
+          if (vtts != null) {
+            deltaOp.set(VTTS_SNAPSHOT_PROP, Long.toString(vtts.toInstant().toEpochMilli()));
+          }
+          addTxDataToSnapshot(deltaOp, txIdValidThrough, maxTxId);
+          dataFiles.forEach(deltaOp::addRows);
+          deleteFiles.forEach(deltaOp::addDeletes);
+          deltaOp.commit();
         }
 
-        transaction.commitTransaction();
-      } else {
-        RowDelta deltaOp = table.newRowDelta();
-        branch.ifPresent(deltaOp::toBranch);
-        deltaOp.set(snapshotOffsetsProp, offsetsJson);
-        deltaOp.set(COMMIT_ID_SNAPSHOT_PROP, commitState.currentCommitId().toString());
-        if (vtts != null) {
-          deltaOp.set(VTTS_SNAPSHOT_PROP, Long.toString(vtts.toInstant().toEpochMilli()));
-        }
-        addTxDataToSnapshot(deltaOp, txIdValidThrough, maxTxId);
-        dataFiles.forEach(deltaOp::addRows);
-        deleteFiles.forEach(deltaOp::addDeletes);
-        deltaOp.commit();
+        Long snapshotId = latestSnapshot(table, branch.orElse(null)).snapshotId();
+
+        LOG.debug("Committed snapshot: snapshotId={}, tableIdentifier={}, commitId={}, vtts={}, " +
+                        "txIdValidThrough={}, maxTxId={}, dataFiles={}, deleteFiles={}, highestTxIds={}",
+                snapshotId, tableIdentifier, commitState.currentCommitId(), vtts,
+                txIdValidThrough, maxTxId, dataFiles.size(), deleteFiles.size(), tableHighestTxIds);
+
+        Event event =
+                new Event(
+                        config.controlGroupId(),
+                        new CommitToTable(
+                                commitState.currentCommitId(),
+                                TableReference.of(config.catalogName(), tableIdentifier),
+                                snapshotId,
+                                vtts));
+        send(event);
+
+        LOG.info(
+                "Commit complete to table {}, snapshot {}, commit ID {}, vtts {}",
+                tableIdentifier,
+                snapshotId,
+                commitState.currentCommitId(),
+                vtts);
+      } catch (Exception e) {
+        LOG.error(
+                "Commit failed for table {}, commit ID {}, vtts {}, partial {}, data files {}, delete files {}",
+                tableIdentifier,
+                commitState.currentCommitId(),
+                vtts,
+                partialCommit,
+                dataFiles.size(),
+                deleteFiles.size(),
+                e);
+        throw e;
       }
-
-      Long snapshotId = latestSnapshot(table, branch.orElse(null)).snapshotId();
-
-      LOG.debug("Committed snapshot: snapshotId={}, tableIdentifier={}, commitId={}, vtts={}, " +
-                      "txIdValidThrough={}, maxTxId={}, dataFiles={}, deleteFiles={}, highestTxIds={}",
-              snapshotId, tableIdentifier, commitState.currentCommitId(), vtts,
-              txIdValidThrough, maxTxId, dataFiles.size(), deleteFiles.size(), tableHighestTxIds);
-
-      Event event =
-          new Event(
-              config.controlGroupId(),
-              new CommitToTable(
-                  commitState.currentCommitId(),
-                  TableReference.of(config.catalogName(), tableIdentifier),
-                  snapshotId,
-                  vtts));
-      send(event);
-
-      LOG.info(
-          "Commit complete to table {}, snapshot {}, commit ID {}, vtts {}",
-          tableIdentifier,
-          snapshotId,
-          commitState.currentCommitId(),
-          vtts);
-    } catch (Exception e) {
-      LOG.error(
-              "Commit failed for table {}, commit ID {}, vtts {}, partial {}, data files {}, delete files {}",
-              tableIdentifier,
-              commitState.currentCommitId(),
-              vtts,
-              partialCommit,
-              dataFiles.size(),
-              deleteFiles.size(),
-              e);
-      throw e;
     }
   }
   /**
@@ -387,7 +381,7 @@ public class Coordinator extends Channel implements AutoCloseable {
       operation.set(TXID_MAX_PROP, Long.toString(maxTxId));
       LOG.info("Added transaction data to snapshot: validThrough={}, max={}", txIdValidThrough, maxTxId);
     } else {
-        LOG.warn("No transaction data to add to snapshot");
+      LOG.warn("No transaction data to add to snapshot");
     }
   }
 


### PR DESCRIPTION
https://rapid7.atlassian.net/browse/USD-4123

Before a commit is attempted on a table, the current snapshot ID and table is now logged. Can helps to understand the state of the table right before the commit operation and figure out if there is multiple commits started.

In the event of a commit failure, a detailed error message is logged. This message includes the table identifier, commit ID, VTTS, whether the commit was partial, and the number of data and delete files involved.